### PR TITLE
Update aws-sdk gem to v2.0.36

### DIFF
--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 2"
+  spec.add_dependency "aws-sdk", "~> 2.0", ">= 2.0.36"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
[aws-sdk-ruby v2.0.36](https://github.com/aws/aws-sdk-ruby/releases/tag/v2.0.36) is released!
This includes a fix for stubbing `nil` value.