### PR TITLE
Normalize module name

### DIFF
--- a/lib/terraforming/resource.rb
+++ b/lib/terraforming/resource.rb
@@ -8,6 +8,10 @@ module Terraforming::Resource
     name_tag ? name_tag.value : default_name
   end
 
+  def self.normalize_module_name(name)
+    name.gsub(/[^a-zA-Z0-9_-]/, "-")
+  end
+
   def self.template_path(template_name)
     File.join(File.expand_path(File.dirname(__FILE__)), "template", template_name) << ".erb"
   end

--- a/lib/terraforming/resource/db_parameter_group.rb
+++ b/lib/terraforming/resource/db_parameter_group.rb
@@ -13,7 +13,7 @@ module Terraforming::Resource
           "name" => parameter_group.db_parameter_group_name,
           "parameter.#" => client.describe_db_parameters(db_parameter_group_name: parameter_group.db_parameter_group_name).parameters.length.to_s
         }
-        result["aws_db_parameter_group.#{parameter_group.db_parameter_group_name}"] = {
+        result["aws_db_parameter_group.#{Terraforming::Resource.normalize_module_name(parameter_group.db_parameter_group_name)}"] = {
           "type" => "aws_db_parameter_group",
           "primary" => {
             "id" => parameter_group.db_parameter_group_name,

--- a/lib/terraforming/resource/db_security_group.rb
+++ b/lib/terraforming/resource/db_security_group.rb
@@ -12,7 +12,7 @@ module Terraforming::Resource
           "ingress.#" => (security_group.ec2_security_groups.length + security_group.ip_ranges.length).to_s,
           "name" => security_group.db_security_group_name,
         }
-        result["aws_db_security_group.#{security_group.db_security_group_name}"] = {
+        result["aws_db_security_group.#{Terraforming::Resource.normalize_module_name(security_group.db_security_group_name)}"] = {
           "type" => "aws_db_security_group",
           "primary" => {
             "id" => security_group.db_security_group_name,

--- a/lib/terraforming/resource/db_subnet_group.rb
+++ b/lib/terraforming/resource/db_subnet_group.rb
@@ -11,7 +11,7 @@ module Terraforming::Resource
           "name" => subnet_group.db_subnet_group_name,
           "subnet_ids.#" => subnet_group.subnets.length.to_s
         }
-        result["aws_db_subnet_group.#{subnet_group.db_subnet_group_name}"] = {
+        result["aws_db_subnet_group.#{Terraforming::Resource.normalize_module_name(subnet_group.db_subnet_group_name)}"] = {
           "type" => "aws_db_subnet_group",
           "primary" => {
             "id" => subnet_group.db_subnet_group_name,

--- a/lib/terraforming/resource/ec2.rb
+++ b/lib/terraforming/resource/ec2.rb
@@ -25,7 +25,7 @@ module Terraforming::Resource
           "subnet_id"=> instance.subnet_id,
           "tenancy"=> instance.placement.tenancy
         }
-        result["aws_instance.#{Terraforming::Resource.name_from_tag(instance, instance.instance_id)}"] = {
+        result["aws_instance.#{Terraforming::Resource.normalize_module_name(Terraforming::Resource.name_from_tag(instance, instance.instance_id))}"] = {
           "type" => "aws_instance",
           "primary" => {
             "id" => instance.instance_id,

--- a/lib/terraforming/resource/elb.rb
+++ b/lib/terraforming/resource/elb.rb
@@ -17,7 +17,7 @@ module Terraforming::Resource
           "security_groups.#" => load_balancer.security_groups.length.to_s,
           "subnets.#" => load_balancer.subnets.length.to_s,
         }
-        result["aws_elb.#{load_balancer.load_balancer_name}"] = {
+        result["aws_elb.#{Terraforming::Resource.normalize_module_name(load_balancer.load_balancer_name)}"] = {
           "type" => "aws_elb",
           "primary" => {
             "id" => load_balancer.load_balancer_name,

--- a/lib/terraforming/resource/rds.rb
+++ b/lib/terraforming/resource/rds.rb
@@ -33,7 +33,7 @@ module Terraforming::Resource
           "username" => instance.master_username,
           "vpc_security_group_ids.#" => instance.vpc_security_groups.length.to_s,
         }
-        result["aws_db_instance.#{instance.db_instance_identifier}"] = {
+        result["aws_db_instance.#{Terraforming::Resource.normalize_module_name(instance.db_instance_identifier)}"] = {
           "type" => "aws_db_instance",
           "primary" => {
             "id" => instance.db_instance_identifier,

--- a/lib/terraforming/resource/s3.rb
+++ b/lib/terraforming/resource/s3.rb
@@ -6,7 +6,7 @@ module Terraforming::Resource
 
     def self.tfstate(client = Aws::S3::Client.new)
       resources = client.list_buckets.buckets.inject({}) do |result, bucket|
-        result["aws_s3_bucket.#{bucket.name}"] = {
+        result["aws_s3_bucket.#{Terraforming::Resource.normalize_module_name(bucket.name)}"] = {
           "type" => "aws_s3_bucket",
           "primary" => {
             "id" => bucket.name,

--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -16,7 +16,7 @@ module Terraforming::Resource
           "owner_id" => security_group.owner_id,
           "vpc_id" => security_group.vpc_id || "",
         }
-        result["aws_security_group.#{security_group.group_name}"] = {
+        result["aws_security_group.#{Terraforming::Resource.normalize_module_name(security_group.group_name)}"] = {
           "type" => "aws_security_group",
           "primary" => {
             "id" => security_group.group_id,

--- a/lib/terraforming/resource/vpc.rb
+++ b/lib/terraforming/resource/vpc.rb
@@ -12,7 +12,7 @@ module Terraforming::Resource
           "instance_tenancy" => vpc.instance_tenancy,
           "tags.#" => vpc.tags.length.to_s,
         }
-        result["aws_vpc.#{Terraforming::Resource.name_from_tag(vpc, vpc.vpc_id)}"] = {
+        result["aws_vpc.#{Terraforming::Resource.normalize_module_name(Terraforming::Resource.name_from_tag(vpc, vpc.vpc_id))}"] = {
           "type" => "aws_vpc",
           "primary" => {
             "id" => vpc.vpc_id,

--- a/lib/terraforming/template/tf/db_parameter_group.erb
+++ b/lib/terraforming/template/tf/db_parameter_group.erb
@@ -1,5 +1,5 @@
 <% client.describe_db_parameter_groups.db_parameter_groups.each do |parameter_group| -%>
-resource "aws_db_parameter_group" "<%= parameter_group.db_parameter_group_name %>" {
+resource "aws_db_parameter_group" "<%= Terraforming::Resource.normalize_module_name(parameter_group.db_parameter_group_name) %>" {
     name        = "<%= parameter_group.db_parameter_group_name %>"
     family      = "<%= parameter_group.db_parameter_group_family %>"
     description = "<%= parameter_group.description %>"

--- a/lib/terraforming/template/tf/db_security_group.erb
+++ b/lib/terraforming/template/tf/db_security_group.erb
@@ -1,5 +1,5 @@
 <% client.describe_db_security_groups.db_security_groups.each do |security_group| -%>
-resource "aws_db_security_group" "<%= security_group.db_security_group_name %>" {
+resource "aws_db_security_group" "<%= Terraforming::Resource.normalize_module_name(security_group.db_security_group_name) %>" {
     name        = "<%= security_group.db_security_group_name %>"
     description = "<%= security_group.db_security_group_description %>"
 

--- a/lib/terraforming/template/tf/db_subnet_group.erb
+++ b/lib/terraforming/template/tf/db_subnet_group.erb
@@ -1,5 +1,5 @@
 <% client.describe_db_subnet_groups.db_subnet_groups.each do |subnet_group| -%>
-resource "aws_db_subnet_group" "<%= subnet_group.db_subnet_group_name %>" {
+resource "aws_db_subnet_group" "<%= Terraforming::Resource.normalize_module_name(subnet_group.db_subnet_group_name) %>" {
     name        = "<%= subnet_group.db_subnet_group_name %>"
     description = "<%= subnet_group.db_subnet_group_description %>"
     subnet_ids  = <%= subnet_group.subnets.map { |subnet| subnet.subnet_identifier }.inspect %>

--- a/lib/terraforming/template/tf/ec2.erb
+++ b/lib/terraforming/template/tf/ec2.erb
@@ -1,5 +1,5 @@
 <% client.describe_instances.reservations.map(&:instances).flatten.each do |instance| -%>
-resource "aws_instance" "<%= Terraforming::Resource.name_from_tag(instance, instance.instance_id) %>" {
+resource "aws_instance" "<%= Terraforming::Resource.normalize_module_name(Terraforming::Resource.name_from_tag(instance, instance.instance_id)) %>" {
     ami                         = "<%= instance.image_id %>"
     availability_zone           = "<%= instance.placement.availability_zone %>"
     ebs_optimized               = <%= instance.ebs_optimized %>

--- a/lib/terraforming/template/tf/elb.erb
+++ b/lib/terraforming/template/tf/elb.erb
@@ -1,5 +1,5 @@
 <% client.describe_load_balancers.load_balancer_descriptions.each do |load_balancer| -%>
-resource "aws_elb" "<%= load_balancer.load_balancer_name %>" {
+resource "aws_elb" "<%= Terraforming::Resource.normalize_module_name(load_balancer.load_balancer_name) %>" {
     name               = "<%= load_balancer.load_balancer_name %>"
     availability_zones = <%= load_balancer.availability_zones.inspect %>
     subnets            = <%= load_balancer.subnets.inspect %>

--- a/lib/terraforming/template/tf/rds.erb
+++ b/lib/terraforming/template/tf/rds.erb
@@ -1,6 +1,6 @@
 <% client.describe_db_instances.db_instances.each do |instance| -%>
 resource "aws_db_instance" "<%= instance.db_instance_identifier %>" {
-    identifier                = "<%= instance.db_instance_identifier %>"
+    identifier                = "<%= Terraforming::Resource.normalize_module_name(instance.db_instance_identifier) %>"
     allocated_storage         = <%= instance.allocated_storage %>
     storage_type              = "<%= instance.storage_type %>"
     engine                    = "<%= instance.engine %>"

--- a/lib/terraforming/template/tf/s3.erb
+++ b/lib/terraforming/template/tf/s3.erb
@@ -1,5 +1,5 @@
 <% client.list_buckets.buckets.each do |bucket| -%>
-resource "aws_s3_bucket" "<%= bucket.name %>" {
+resource "aws_s3_bucket" "<%= Terraforming::Resource.normalize_module_name(bucket.name) %>" {
     bucket = "<%= bucket.name %>"
     acl    = "private"
 }

--- a/lib/terraforming/template/tf/security_group.erb
+++ b/lib/terraforming/template/tf/security_group.erb
@@ -1,5 +1,5 @@
 <% client.describe_security_groups.security_groups.each do |security_group| -%>
-resource "aws_security_group" "<%= security_group.group_name %>" {
+resource "aws_security_group" "<%= Terraforming::Resource.normalize_module_name(security_group.group_name) %>" {
     name        = "<%= security_group.group_name %>"
     description = "<%= security_group.description %>"
     owner_id    = "<%= security_group.owner_id %>"

--- a/lib/terraforming/template/tf/vpc.erb
+++ b/lib/terraforming/template/tf/vpc.erb
@@ -1,5 +1,5 @@
 <% client.describe_vpcs.vpcs.each do |vpc| -%>
-resource "aws_vpc" "<%= Terraforming::Resource.name_from_tag(vpc, vpc.vpc_id) %>" {
+resource "aws_vpc" "<%= Terraforming::Resource.normalize_module_name(Terraforming::Resource.name_from_tag(vpc, vpc.vpc_id)) %>" {
     cidr_block       = "<%= vpc.cidr_block %>"
     instance_tenancy = "<%= vpc.instance_tenancy %>"
 

--- a/spec/lib/terraforming/resource/db_parameter_group_spec.rb
+++ b/spec/lib/terraforming/resource/db_parameter_group_spec.rb
@@ -87,7 +87,7 @@ module Terraforming::Resource
     describe ".tf" do
       it "should generate tf" do
         expect(described_class.tf(client)).to eq <<-EOS
-resource "aws_db_parameter_group" "default.mysql5.6" {
+resource "aws_db_parameter_group" "default-mysql5-6" {
     name        = "default.mysql5.6"
     family      = "mysql5.6"
     description = "Default parameter group for mysql5.6"
@@ -106,7 +106,7 @@ resource "aws_db_parameter_group" "default.mysql5.6" {
 
 }
 
-resource "aws_db_parameter_group" "default.postgres9.4" {
+resource "aws_db_parameter_group" "default-postgres9-4" {
     name        = "default.postgres9.4"
     family      = "postgres9.4"
     description = "Default parameter group for postgres9.4"
@@ -139,7 +139,7 @@ resource "aws_db_parameter_group" "default.postgres9.4" {
               ],
               "outputs" => {},
               "resources" => {
-                "aws_db_parameter_group.default.mysql5.6" => {
+                "aws_db_parameter_group.default-mysql5-6" => {
                   "type" => "aws_db_parameter_group",
                   "primary" => {
                     "id" => "default.mysql5.6",
@@ -152,7 +152,7 @@ resource "aws_db_parameter_group" "default.postgres9.4" {
                     }
                   }
                 },
-                "aws_db_parameter_group.default.postgres9.4" => {
+                "aws_db_parameter_group.default-postgres9-4" => {
                   "type" => "aws_db_parameter_group",
                   "primary" => {
                     "id" => "default.postgres9.4",


### PR DESCRIPTION
To avoid this error:

```
There are warnings and/or errors related to your configuration. Please
fix these before continuing.

Warnings:

  * aws_db_parameter_group.default.postgres9.3: module name can only contain letters, numbers, dashes, and underscores.
This will be an error in Terraform 0.4
  * aws_db_parameter_group.default.mysql5.6: module name can only contain letters, numbers, dashes, and underscores.
This will be an error in Terraform 0.4
```