### PR TITLE
Introduce Oj and Ox

### DIFF
--- a/lib/terraforming.rb
+++ b/lib/terraforming.rb
@@ -1,3 +1,6 @@
+require "oj"
+require "ox"
+
 require "aws-sdk-core"
 require "erb"
 require "json"

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk", "~> 2.0", ">= 2.0.36"
   spec.add_dependency "oj"
+  spec.add_dependency "ox"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "aws-sdk", "~> 2.0", ">= 2.0.36"
+  spec.add_dependency "oj"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
[AWS SDK for Ruby and Nokogiri - AWS Developer Blog - Ruby](https://ruby.awsblog.com/post/Tx2T9MFQJK7U74N/AWS-SDK-for-Ruby-and-Nokogiri)

> Version 2 of the Ruby SDK no longer relies directly on Nokogiri. Instead it has dependencies on multi_xml and multi_json. This allows you to use Ox and Oj for speed, or Nokogiri if you prefer. Additionally, the Ruby SDK will work with pure Ruby XML and JSON parsing libraries which makes distributing to varied environments much simpler.