### PR TITLE
Include ELB additional attributes

### DIFF
--- a/lib/terraforming/resource/elb.rb
+++ b/lib/terraforming/resource/elb.rb
@@ -21,11 +21,16 @@ module Terraforming
 
       def tfstate
         resources = load_balancers.inject({}) do |result, load_balancer|
+          load_balancer_attributes = load_balancer_attributes_of(load_balancer)
           attributes = {
             "availability_zones.#" => load_balancer.availability_zones.length.to_s,
+            "connection_draining" => load_balancer_attributes.connection_draining.enabled.to_s,
+            "connection_draining_timeout" => load_balancer_attributes.connection_draining.timeout.to_s,
+            "cross_zone_load_balancing" => load_balancer_attributes.cross_zone_load_balancing.enabled.to_s,
             "dns_name" => load_balancer.dns_name,
             "health_check.#" => "1",
             "id" => load_balancer.load_balancer_name,
+            "idle_timeout" => load_balancer_attributes.connection_settings.idle_timeout.to_s,
             "instances.#" => load_balancer.instances.length.to_s,
             "listener.#" => load_balancer.listener_descriptions.length.to_s,
             "name" => load_balancer.load_balancer_name,

--- a/lib/terraforming/resource/elb.rb
+++ b/lib/terraforming/resource/elb.rb
@@ -50,6 +50,10 @@ module Terraforming
         @client.describe_load_balancers.load_balancer_descriptions
       end
 
+      def load_balancer_attributes_of(load_balancer)
+        @client.describe_load_balancer_attributes(load_balancer_name: load_balancer.load_balancer_name).load_balancer_attributes
+      end
+
       def module_name_of(load_balancer)
         normalize_module_name(load_balancer.load_balancer_name)
       end

--- a/lib/terraforming/template/tf/elb.erb
+++ b/lib/terraforming/template/tf/elb.erb
@@ -1,10 +1,15 @@
 <% load_balancers.each do |load_balancer| -%>
+  <%- load_balancer_attributes = load_balancer_attributes_of(load_balancer) -%>
 resource "aws_elb" "<%= module_name_of(load_balancer) %>" {
-    name               = "<%= load_balancer.load_balancer_name %>"
-    availability_zones = <%= load_balancer.availability_zones.inspect %>
-    subnets            = <%= load_balancer.subnets.inspect %>
-    security_groups    = <%= load_balancer.security_groups.inspect %>
-    instances          = <%= load_balancer.instances.map { |instance| instance.instance_id }.inspect %>
+    name                        = "<%= load_balancer.load_balancer_name %>"
+    availability_zones          = <%= load_balancer.availability_zones.inspect %>
+    subnets                     = <%= load_balancer.subnets.inspect %>
+    security_groups             = <%= load_balancer.security_groups.inspect %>
+    instances                   = <%= load_balancer.instances.map { |instance| instance.instance_id }.inspect %>
+    cross_zone_load_balancing   = <%= load_balancer_attributes.cross_zone_load_balancing.enabled %>
+    idle_timeout                = <%= load_balancer_attributes.connection_settings.idle_timeout %>
+    connection_draining         = <%= load_balancer_attributes.connection_draining.enabled %>
+    connection_draining_timeout = <%= load_balancer_attributes.connection_draining.timeout %>
 
 <% load_balancer.listener_descriptions.map { |ld| ld.listener }.map do |listener| -%>
     listener {

--- a/spec/lib/terraforming/resource/elb_spec.rb
+++ b/spec/lib/terraforming/resource/elb_spec.rb
@@ -224,7 +224,7 @@ resource "aws_elb" "fuga" {
       end
 
       describe ".tfstate" do
-        xit "should generate tfstate" do
+        it "should generate tfstate" do
           expect(described_class.tfstate(client)).to eq JSON.pretty_generate({
             "version" => 1,
             "serial" => 1,
@@ -240,9 +240,13 @@ resource "aws_elb" "fuga" {
                     "id" => "hoge",
                     "attributes" => {
                       "availability_zones.#" => "2",
+                      "connection_draining" => "true",
+                      "connection_draining_timeout" => "300",
+                      "cross_zone_load_balancing" => "true",
                       "dns_name" => "hoge-12345678.ap-northeast-1.elb.amazonaws.com",
                       "health_check.#" => "1",
                       "id" => "hoge",
+                      "idle_timeout" => "60",
                       "instances.#" => "1",
                       "listener.#" => "1",
                       "name" => "hoge",
@@ -257,9 +261,13 @@ resource "aws_elb" "fuga" {
                     "id" => "fuga",
                     "attributes" => {
                       "availability_zones.#" => "2",
+                      "connection_draining" => "true",
+                      "connection_draining_timeout" => "900",
+                      "cross_zone_load_balancing" => "true",
                       "dns_name" => "fuga-90123456.ap-northeast-1.elb.amazonaws.com",
                       "health_check.#" => "1",
                       "id" => "fuga",
+                      "idle_timeout" => "90",
                       "instances.#" => "1",
                       "listener.#" => "1",
                       "name" => "fuga",


### PR DESCRIPTION
## WHY

ELB additional attributes are supported at Terraform v0.5.0.

## WHAY

Include these additional attributes in generated tf and tfstate.

## REF
- [DescribeLoadBalancerAttributes - Elastic Load Balancing](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_DescribeLoadBalancerAttributes.html)
- [Implement Additional ELB Connection Attributes · hashicorp/terraform@74bfbec](https://github.com/hashicorp/terraform/commit/74bfbece69e6826836ae6820ad0cfa494d689128)