### PR TITLE
Omit default Network ACL rule

### DIFF
--- a/lib/terraforming/resource/network_acl.rb
+++ b/lib/terraforming/resource/network_acl.rb
@@ -44,8 +44,16 @@ module Terraforming
 
       private
 
+      def default_entry?(entry)
+        entry.rule_number == default_rule_number
+      end
+
+      def default_rule_number
+        32767
+      end
+
       def egresses_of(network_acl)
-        network_acl.entries.select { |entry| entry.egress }
+        network_acl.entries.select { |entry| entry.egress && !default_entry?(entry) }
       end
 
       def from_port_of(entry)
@@ -53,7 +61,7 @@ module Terraforming
       end
 
       def ingresses_of(network_acl)
-        network_acl.entries.select { |entry| !entry.egress }
+        network_acl.entries.select { |entry| !entry.egress && !default_entry?(entry) }
       end
 
       def module_name_of(network_acl)

--- a/spec/lib/terraforming/resource/network_acl_spec.rb
+++ b/spec/lib/terraforming/resource/network_acl_spec.rb
@@ -113,15 +113,6 @@ resource "aws_network_acl" "hoge" {
         cidr_block = "0.0.0.0/0"
     }
 
-    egress {
-        from_port  = 80
-        to_port    = 80
-        rule_no    = 32767
-        action     = "deny"
-        protocol   = "-1"
-        cidr_block = "0.0.0.0/0"
-    }
-
     tags {
         Name = "hoge"
     }
@@ -135,15 +126,6 @@ resource "aws_network_acl" "fuga" {
         to_port    = 65535
         rule_no    = 100
         action     = "allow"
-        protocol   = "-1"
-        cidr_block = "0.0.0.0/0"
-    }
-
-    egress {
-        from_port  = 80
-        to_port    = 80
-        rule_no    = 32767
-        action     = "deny"
         protocol   = "-1"
         cidr_block = "0.0.0.0/0"
     }
@@ -173,7 +155,7 @@ resource "aws_network_acl" "fuga" {
                   "primary" => {
                     "id" => "acl-1234abcd",
                     "attributes" => {
-                      "egress.#" => "1",
+                      "egress.#" => "0",
                       "id" => "acl-1234abcd",
                       "ingress.#" => "1",
                       "tags.#" => "1",
@@ -186,7 +168,7 @@ resource "aws_network_acl" "fuga" {
                   "primary" => {
                     "id" => "acl-5678efgh",
                     "attributes" => {
-                      "egress.#" => "1",
+                      "egress.#" => "0",
                       "id" => "acl-5678efgh",
                       "ingress.#" => "1",
                       "tags.#" => "1",


### PR DESCRIPTION
Rule number `32767` means default rule, which we cannot modify or delete. 
We should omit this rule.

## REF
- [aws: Don't try to modify or delete the untouchable network_acl rules. · ctiwald/terraform@d14049c](https://github.com/ctiwald/terraform/commit/d14049c8ad32a52c3d53f5eb4f48cc908b3ce644)
- [Network ACLs - Amazon Virtual Private Cloud](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_ACLs.html)

> Each network ACL includes a rule whose rule number is an asterisk. This rule ensures that if a packet doesn't match any of the other rules, it's denied. You can't modify or remove this rule.