### PR TITLE
Fix default max port number of Network ACL

### DIFF
--- a/lib/terraforming/resource/network_acl.rb
+++ b/lib/terraforming/resource/network_acl.rb
@@ -73,7 +73,7 @@ module Terraforming
       end
 
       def to_port_of(entry)
-        entry.port_range ? entry.port_range.to : 65535
+        entry.port_range ? entry.port_range.to : 0
       end
     end
   end

--- a/spec/lib/terraforming/resource/network_acl_spec.rb
+++ b/spec/lib/terraforming/resource/network_acl_spec.rb
@@ -106,7 +106,7 @@ resource "aws_network_acl" "hoge" {
 
     ingress {
         from_port  = 0
-        to_port    = 65535
+        to_port    = 0
         rule_no    = 100
         action     = "allow"
         protocol   = "-1"
@@ -123,7 +123,7 @@ resource "aws_network_acl" "fuga" {
 
     ingress {
         from_port  = 0
-        to_port    = 65535
+        to_port    = 0
         rule_no    = 100
         action     = "allow"
         protocol   = "-1"


### PR DESCRIPTION
If port range from API is not set, the port in Terraform should be [0, 0]

## REF

- [aws: Force users to use from_port, to_port = 0 on network ACLs with -… · ctiwald/terraform@b888b31](https://github.com/ctiwald/terraform/commit/b888b31e08ea723cfcd1cc688f9934c9c9f601ea)