### PR TITLE
Fix breaklines in policy document tf

### DIFF
--- a/lib/terraforming/template/tf/iam_group_policy.erb
+++ b/lib/terraforming/template/tf/iam_group_policy.erb
@@ -3,7 +3,7 @@ resource "aws_iam_group_policy" "<%= policy.policy_name %>" {
     name   = "<%= policy.policy_name %>"
     group  = "<%= policy.group_name %>"
     policy = <<EOF
-<%= CGI.unescape(policy.policy_document) -%>
+<%= CGI.unescape(policy.policy_document).strip %>
 EOF
 }
 

--- a/lib/terraforming/template/tf/iam_user_policy.erb
+++ b/lib/terraforming/template/tf/iam_user_policy.erb
@@ -3,7 +3,7 @@ resource "aws_iam_user_policy" "<%= policy.policy_name %>" {
     name   = "<%= policy.policy_name %>"
     user   = "<%= policy.user_name %>"
     policy = <<EOF
-<%= CGI.unescape(policy.policy_document) -%>
+<%= CGI.unescape(policy.policy_document).strip %>
 EOF
 }
 


### PR DESCRIPTION
## WHY

Sometimes Terraforming generates invalid tf of IAM user policy and IAM group policy:

```
resource "aws_iam_user_policy" "hoge_policy" {
    name   = "hoge_policy"
    user   = "hoge"
    policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "ec2:Describe*"
      ],
      "Effect": "Allow",
      "Resource": "*"
    }
  ]
}EOF # !!!
}
```

## WHAT

Fix to generate valid tf always.

```
resource "aws_iam_user_policy" "hoge_policy" {
    name   = "hoge_policy"
    user   = "hoge"
    policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "ec2:Describe*"
      ],
      "Effect": "Allow",
      "Resource": "*"
    }
  ]
}
EOF
}
```