### PR TITLE
Fix Route53Record typo

### DIFF
--- a/lib/terraforming/template/tf/route53_record.erb
+++ b/lib/terraforming/template/tf/route53_record.erb
@@ -22,7 +22,7 @@ resource "aws_route53_record" "<%= module_name_of(record) %>" {
         name    = "<%= name_of(record.alias_target.dns_name)
  %>"
         zone_id = "<%= record.alias_target.hosted_zone_id %>"
-        evaluate_target_length = <%= record.alias_target.evaluate_target_health %>
+        evaluate_target_health = <%= record.alias_target.evaluate_target_health %>
     }
     <%- end -%>
 }

--- a/spec/lib/terraforming/resource/route53_record_spec.rb
+++ b/spec/lib/terraforming/resource/route53_record_spec.rb
@@ -89,7 +89,7 @@ resource "aws_route53_record" "www-fuga-net" {
     alias {
         name    = "fuga.net"
         zone_id = "ABCDEFGHIJ1234"
-        evaluate_target_length = false
+        evaluate_target_health = false
     }
 }
 


### PR DESCRIPTION
`evaluate_target_length` :point_right: `evaluate_target_health`