### PR TITLE
Add group id to SecurityGroup module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.1.0 (UNRELEASED)
+
+### Fixed
+
+- Set unique module name to SecurityGroup
+
 # [v0.0.3](https://github.com/dtan4/terraforming/releases/tag/v0.0.3) (2015-05-26)
 
 ### Fixed

--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -47,7 +47,7 @@ module Terraforming
       private
 
       def module_name_of(security_group)
-        normalize_module_name(security_group.group_name)
+        normalize_module_name("#{security_group.group_id}-#{security_group.group_name}")
       end
 
       def security_groups

--- a/spec/lib/terraforming/resource/security_group_spec.rb
+++ b/spec/lib/terraforming/resource/security_group_spec.rb
@@ -82,7 +82,7 @@ module Terraforming
       describe ".tf" do
         it "should generate tf" do
           expect(described_class.tf(client)).to eq <<-EOS
-resource "aws_security_group" "hoge" {
+resource "aws_security_group" "sg-1234abcd-hoge" {
     name        = "hoge"
     description = "Group for hoge"
     owner_id    = "012345678901"
@@ -105,7 +105,7 @@ resource "aws_security_group" "hoge" {
 
 }
 
-resource "aws_security_group" "fuga" {
+resource "aws_security_group" "sg-5678efgh-fuga" {
     name        = "fuga"
     description = "Group for fuga"
     owner_id    = "098765432109"
@@ -146,7 +146,7 @@ resource "aws_security_group" "fuga" {
               ],
               "outputs" => {},
               "resources" => {
-                "aws_security_group.hoge" => {
+                "aws_security_group.sg-1234abcd-hoge" => {
                   "type" => "aws_security_group",
                   "primary" => {
                     "id" => "sg-1234abcd",
@@ -161,7 +161,7 @@ resource "aws_security_group" "fuga" {
                     }
                   }
                 },
-                "aws_security_group.fuga" => {
+                "aws_security_group.sg-5678efgh-fuga" => {
                   "type" => "aws_security_group",
                   "primary" => {
                     "id" => "sg-5678efgh",


### PR DESCRIPTION
Add `group_id` to SecurityGroup module name to keep uniqueness, because SecurityGroup `name` field allows duplication.