### PR TITLE
Remove owner_id argument from SecurityGroup tf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Fixed
 
-- Set unique module name to SecurityGroup
+- Set unique module name to SecurityGroup #53
+- Remove `owner_id` argument from SecurityGroup #54
 
 # [v0.0.3](https://github.com/dtan4/terraforming/releases/tag/v0.0.3) (2015-05-26)
 

--- a/lib/terraforming/template/tf/security_group.erb
+++ b/lib/terraforming/template/tf/security_group.erb
@@ -2,7 +2,6 @@
 resource "aws_security_group" "<%= module_name_of(security_group) %>" {
     name        = "<%= security_group.group_name %>"
     description = "<%= security_group.description %>"
-    owner_id    = "<%= security_group.owner_id %>"
     vpc_id      = "<%= security_group.vpc_id || '' %>"
 
 <% security_group.ip_permissions.each do |permission| -%>

--- a/spec/lib/terraforming/resource/security_group_spec.rb
+++ b/spec/lib/terraforming/resource/security_group_spec.rb
@@ -85,7 +85,6 @@ module Terraforming
 resource "aws_security_group" "sg-1234abcd-hoge" {
     name        = "hoge"
     description = "Group for hoge"
-    owner_id    = "012345678901"
     vpc_id      = ""
 
     ingress {
@@ -108,7 +107,6 @@ resource "aws_security_group" "sg-1234abcd-hoge" {
 resource "aws_security_group" "sg-5678efgh-fuga" {
     name        = "fuga"
     description = "Group for fuga"
-    owner_id    = "098765432109"
     vpc_id      = "vpc-1234abcd"
 
     ingress {


### PR DESCRIPTION
SecurityGroup resource does not allow `owner_id` argument.

[AWS: aws_security_group - Terraform by HashiCorp](https://www.terraform.io/docs/providers/aws/r/security_group.html)