### PR TITLE
Quote tag name

### DIFF
--- a/lib/terraforming/template/tf/ec2.erb
+++ b/lib/terraforming/template/tf/ec2.erb
@@ -19,7 +19,7 @@ resource "aws_instance" "<%= module_name_of(instance) %>" {
 <% end -%>
     tags {
 <% instance.tags.each do |tag| -%>
-        <%= tag.key %> = "<%= tag.value %>"
+        "<%= tag.key %>" = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/network_acl.erb
+++ b/lib/terraforming/template/tf/network_acl.erb
@@ -26,7 +26,7 @@ resource "aws_network_acl" "<%= module_name_of(network_acl) %>" {
 <% end -%>
     tags {
 <% network_acl.tags.each do |tag| -%>
-        <%= tag.key %> = "<%= tag.value %>"
+        "<%= tag.key %>" = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/route53_zone.erb
+++ b/lib/terraforming/template/tf/route53_zone.erb
@@ -4,7 +4,7 @@ resource "aws_route53_zone" "<%= module_name_of(hosted_zone) %>" {
 
     tags {
 <% tags_of(hosted_zone).each do |tag| -%>
-        <%= tag.key %> = "<%= tag.value %>"
+        "<%= tag.key %>" = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/security_group.erb
+++ b/lib/terraforming/template/tf/security_group.erb
@@ -36,7 +36,7 @@ resource "aws_security_group" "<%= module_name_of(security_group) %>" {
 <% if security_group.tags.length > 0 -%>
     tags {
 <% security_group.tags.each do |tag| -%>
-        <%= tag.key %> = "<%= tag.value %>"
+        "<%= tag.key %>" = "<%= tag.value %>"
 <% end -%>
     }
 <% end -%>

--- a/lib/terraforming/template/tf/subnet.erb
+++ b/lib/terraforming/template/tf/subnet.erb
@@ -7,7 +7,7 @@ resource "aws_subnet" "<%= module_name_of(subnet) %>" {
 
     tags {
 <% subnet.tags.each do |tag| -%>
-        <%= tag.key %> = "<%= tag.value %>"
+        "<%= tag.key %>" = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/vpc.erb
+++ b/lib/terraforming/template/tf/vpc.erb
@@ -7,7 +7,7 @@ resource "aws_vpc" "<%= module_name_of(vpc) %>" {
 
     tags {
 <% vpc.tags.each do |tag| -%>
-        <%= tag.key %> = "<%= tag.value %>"
+        "<%= tag.key %>" = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/spec/lib/terraforming/resource/ec2_spec.rb
+++ b/spec/lib/terraforming/resource/ec2_spec.rb
@@ -129,7 +129,7 @@ resource "aws_instance" "hoge" {
     }
 
     tags {
-        Name = "hoge"
+        "Name" = "hoge"
     }
 }
 

--- a/spec/lib/terraforming/resource/network_acl_spec.rb
+++ b/spec/lib/terraforming/resource/network_acl_spec.rb
@@ -114,7 +114,7 @@ resource "aws_network_acl" "hoge" {
     }
 
     tags {
-        Name = "hoge"
+        "Name" = "hoge"
     }
 }
 
@@ -131,7 +131,7 @@ resource "aws_network_acl" "fuga" {
     }
 
     tags {
-        Name = "fuga"
+        "Name" = "fuga"
     }
 }
 

--- a/spec/lib/terraforming/resource/route53_zone_spec.rb
+++ b/spec/lib/terraforming/resource/route53_zone_spec.rb
@@ -77,7 +77,7 @@ resource "aws_route53_zone" "hoge-net" {
     name = "hoge.net"
 
     tags {
-        Environment = "dev"
+        "Environment" = "dev"
     }
 }
 
@@ -85,7 +85,7 @@ resource "aws_route53_zone" "fuga-net" {
     name = "fuga.net"
 
     tags {
-        Environment = "dev"
+        "Environment" = "dev"
     }
 }
 

--- a/spec/lib/terraforming/resource/security_group_spec.rb
+++ b/spec/lib/terraforming/resource/security_group_spec.rb
@@ -125,7 +125,7 @@ resource "aws_security_group" "sg-5678efgh-fuga" {
 
 
     tags {
-        Name = "fuga"
+        "Name" = "fuga"
     }
 }
 

--- a/spec/lib/terraforming/resource/subnet_spec.rb
+++ b/spec/lib/terraforming/resource/subnet_spec.rb
@@ -52,7 +52,7 @@ resource "aws_subnet" "hoge" {
     map_public_ip_on_launch = false
 
     tags {
-        Name = "hoge"
+        "Name" = "hoge"
     }
 }
 
@@ -63,7 +63,7 @@ resource "aws_subnet" "fuga" {
     map_public_ip_on_launch = false
 
     tags {
-        Name = "fuga"
+        "Name" = "fuga"
     }
 }
 

--- a/spec/lib/terraforming/resource/vpc_spec.rb
+++ b/spec/lib/terraforming/resource/vpc_spec.rb
@@ -64,7 +64,7 @@ resource "aws_vpc" "hoge" {
     instance_tenancy     = "default"
 
     tags {
-        Name = "hoge"
+        "Name" = "hoge"
     }
 }
 
@@ -75,7 +75,7 @@ resource "aws_vpc" "fuga" {
     instance_tenancy     = "default"
 
     tags {
-        Name = "fuga"
+        "Name" = "fuga"
     }
 }
 


### PR DESCRIPTION
Resolve #58 

## WHY
AWS Resource tag name support some special characters (e.g. `:`) however HCL parser does not support them.

## WHAT
Quote all tag name to make Terraform-valid tag name, to accept tag name containing special chars.