### PR TITLE
Include Network ACL subnet ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v0.1.0 (UNRELEASED)
 
+### Fixed
+
+- Include AWS Network ACL subnet ids
+
 ### Resource
 
 - AWS IAM instance profile

--- a/lib/terraforming/resource/network_acl.rb
+++ b/lib/terraforming/resource/network_acl.rb
@@ -72,6 +72,10 @@ module Terraforming
         @client.describe_network_acls.network_acls
       end
 
+      def subnet_ids_of(network_acl)
+        network_acl.associations.map { |association| association.subnet_id }
+      end
+
       def to_port_of(entry)
         entry.port_range ? entry.port_range.to : 0
       end

--- a/lib/terraforming/resource/network_acl.rb
+++ b/lib/terraforming/resource/network_acl.rb
@@ -25,6 +25,7 @@ module Terraforming
             "egress.#" => egresses_of(network_acl).length.to_s,
             "id" => network_acl.network_acl_id,
             "ingress.#" => ingresses_of(network_acl).length.to_s,
+            "subnet_ids.#" => subnet_ids_of(network_acl).length.to_s,
             "tags.#" => network_acl.tags.length.to_s,
             "vpc_id" => network_acl.vpc_id,
           }

--- a/lib/terraforming/template/tf/network_acl.erb
+++ b/lib/terraforming/template/tf/network_acl.erb
@@ -1,6 +1,7 @@
 <% network_acls.each do |network_acl| -%>
 resource "aws_network_acl" "<%= module_name_of(network_acl) %>" {
-    vpc_id = "<%= network_acl.vpc_id %>"
+    vpc_id     = "<%= network_acl.vpc_id %>"
+    subnet_ids = <%= subnet_ids_of(network_acl).inspect %>
 
 <% ingresses_of(network_acl).each do |ingress| -%>
     ingress {

--- a/spec/lib/terraforming/resource/network_acl_spec.rb
+++ b/spec/lib/terraforming/resource/network_acl_spec.rb
@@ -161,6 +161,7 @@ resource "aws_network_acl" "fuga" {
                         "egress.#" => "0",
                         "id" => "acl-1234abcd",
                         "ingress.#" => "1",
+                        "subnet_ids.#" => "2",
                         "tags.#" => "1",
                         "vpc_id" => "vpc-1234abcd",
                       }
@@ -174,6 +175,7 @@ resource "aws_network_acl" "fuga" {
                         "egress.#" => "0",
                         "id" => "acl-5678efgh",
                         "ingress.#" => "1",
+                        "subnet_ids.#" => "2",
                         "tags.#" => "1",
                         "vpc_id" => "vpc-5678efgh",
                       }

--- a/spec/lib/terraforming/resource/network_acl_spec.rb
+++ b/spec/lib/terraforming/resource/network_acl_spec.rb
@@ -102,7 +102,8 @@ module Terraforming
         it "should generate tf" do
           expect(described_class.tf(client)).to eq <<-EOS
 resource "aws_network_acl" "hoge" {
-    vpc_id = "vpc-1234abcd"
+    vpc_id     = "vpc-1234abcd"
+    subnet_ids = ["subnet-1234abcd", "subnet-5678efgh"]
 
     ingress {
         from_port  = 0
@@ -119,7 +120,8 @@ resource "aws_network_acl" "hoge" {
 }
 
 resource "aws_network_acl" "fuga" {
-    vpc_id = "vpc-5678efgh"
+    vpc_id     = "vpc-5678efgh"
+    subnet_ids = ["subnet-9012ijkl", "subnet-3456mnop"]
 
     ingress {
         from_port  = 0

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 2.0", ">= 2.0.36"
+  # spec.add_dependency "aws-sdk", "~> 2.0", ">= 2.0.36"
+  spec.add_dependency "aws-sdk", "= 2.0.45" # temporarily
   spec.add_dependency "oj"
   spec.add_dependency "ox"
   spec.add_dependency "thor"


### PR DESCRIPTION
## WHAT
Network ACL `subnet_ids` argument is supported from Terraform v0.5.3