### PR TITLE
Security group ingress/egress fix

### DIFF
--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -52,7 +52,7 @@ module Terraforming
       def ingress_attributes_of(security_group)
         attributes = { "ingress.#" => security_group.ip_permissions.length.to_s }
 
-        security_group.ip_permissions.each do |permission|
+        dedup_permissions(security_group).ip_permissions.each do |permission|
           attributes.merge!(permission_attributes_of(security_group, permission, "ingress"))
         end
 
@@ -62,7 +62,7 @@ module Terraforming
       def egress_attributes_of(security_group)
         attributes = { "egress.#" => security_group.ip_permissions_egress.length.to_s }
 
-        security_group.ip_permissions_egress.each do |permission|
+        dedup_permissions(security_group).ip_permissions_egress.each do |permission|
           attributes.merge!(permission_attributes_of(security_group, permission, "egress"))
         end
 

--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -125,14 +125,14 @@ module Terraforming
 
         grouped_egress.each do |range, perms|
           if perms.length == 1
-            security_group.ip_permissions << perms.first
+            security_group.ip_permissions_egress << perms.first
             grouped_egress.delete(range)
           else
             g_ids = perms.map {|perm| perm.user_id_group_pairs}.flatten.map {|gp| gp.group_id}
             if g_ids.length == 1 && g_ids.first == security_group.group_id
-              security_group.ip_permissions << merge_perms(perms)
+              security_group.ip_permissions_egress << merge_perms(perms)
             else
-              security_group.ip_permissions.concat(perms)
+              security_group.ip_permissions_egress.concat(perms)
             end
             grouped_egress.delete(range)
           end

--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -111,7 +111,6 @@ module Terraforming
         grouped_ingress.each do |range, perms|
           if perms.length == 1
             security_group.ip_permissions << perms.first
-            grouped_ingress.delete(range)
           else
             g_ids = perms.map {|perm| perm.user_id_group_pairs}.flatten.map {|gp| gp.group_id}
             if g_ids.length == 1 && g_ids.first == security_group.group_id
@@ -119,14 +118,12 @@ module Terraforming
             else
               security_group.ip_permissions.concat(perms)
             end
-            grouped_ingress.delete(range)
           end
         end
 
         grouped_egress.each do |range, perms|
           if perms.length == 1
             security_group.ip_permissions_egress << perms.first
-            grouped_egress.delete(range)
           else
             g_ids = perms.map {|perm| perm.user_id_group_pairs}.flatten.map {|gp| gp.group_id}
             if g_ids.length == 1 && g_ids.first == security_group.group_id
@@ -134,7 +131,6 @@ module Terraforming
             else
               security_group.ip_permissions_egress.concat(perms)
             end
-            grouped_egress.delete(range)
           end
         end
         security_group

--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -102,8 +102,8 @@ module Terraforming
       end
 
       def dedup_permissions(security_group)
-        grouped_ingress = security_group.ip_permissions.group_by {|perm| [perm.to_port, perm.from_port]}
-        grouped_egress = security_group.ip_permissions_egress.group_by {|perm| [perm.to_port, perm.from_port]}
+        grouped_ingress = security_group.ip_permissions.group_by {|perm| [perm.ip_protocol, perm.to_port, perm.from_port]}
+        grouped_egress = security_group.ip_permissions_egress.group_by {|perm| [perm.ip_protocol, perm.to_port, perm.from_port]}
 
         security_group.ip_permissions = []
         security_group.ip_permissions_egress = []

--- a/lib/terraforming/template/tf/security_group.erb
+++ b/lib/terraforming/template/tf/security_group.erb
@@ -4,7 +4,7 @@ resource "aws_security_group" "<%= module_name_of(security_group) %>" {
     description = "<%= security_group.description %>"
     vpc_id      = "<%= security_group.vpc_id || '' %>"
 
-<% security_group.ip_permissions.each do |permission| -%>
+<% dedup_permissions(security_group).ip_permissions.each do |permission| -%>
   <%- security_groups = security_groups_in(permission).reject { |group_id| group_id == security_group.group_id } -%>
     ingress {
         from_port       = <%= permission.from_port || 0 %>

--- a/lib/terraforming/template/tf/security_group.erb
+++ b/lib/terraforming/template/tf/security_group.erb
@@ -24,7 +24,7 @@ resource "aws_security_group" "<%= module_name_of(security_group) %>" {
 
 <% end -%>
 
-<% security_group.ip_permissions_egress.each do |permission| -%>
+<% dedup_permissions(security_group).ip_permissions_egress.each do |permission| -%>
     egress {
         from_port       = <%= permission.from_port || 0 %>
         to_port         = <%= permission.to_port || 0 %>


### PR DESCRIPTION
In version 0.6.0 of terraform, ingress/egress rules that are both self referencing and contain a CIDR block are sometimes combined in the tfstate output. If the resources are separate in the .tf template, this causes `terraform plan` to show a large diff. This PR will combine rules that have the same protocol and port range, and that are both self referencing and contain a CIDR block. This effects both .tf and .tfstate output. This fixes https://github.com/dtan4/terraforming/issues/92.