### PR TITLE
aws-sdk list_policies has a bug and gets nil description field, this is a workaround

### DIFF
--- a/lib/terraforming/resource/iam_policy.rb
+++ b/lib/terraforming/resource/iam_policy.rb
@@ -24,6 +24,7 @@ module Terraforming
           version = iam_policy_version_of(policy)
           attributes = {
             "id" => policy.arn,
+            "description" => get_policy(policy).description,
             "name" => policy.policy_name,
             "path" => policy.path,
             "policy" => prettify_policy(version.document, true),
@@ -44,6 +45,11 @@ module Terraforming
 
       def iam_policies
         @client.list_policies(scope: "Local").policies
+      end
+
+      ## hack to workaround aws-sdk bug with missing description in list_policies
+      def get_policy(policy)
+        @client.get_policy(policy_arn: policy.arn).policy
       end
 
       def iam_policy_version_of(policy)

--- a/lib/terraforming/template/tf/iam_policy.erb
+++ b/lib/terraforming/template/tf/iam_policy.erb
@@ -1,9 +1,10 @@
 <% iam_policies.each do |policy| -%>
   <%- version = iam_policy_version_of(policy) -%>
 resource "aws_iam_policy" "<%= policy.policy_name %>" {
-    name   = "<%= policy.policy_name %>"
-    path   = "<%= policy.path %>"
-    policy = <<POLICY
+    name        = "<%= policy.policy_name %>"
+    description = "<%= get_policy(policy).description %>"
+    path        = "<%= policy.path %>"
+    policy      = <<POLICY
 <%= prettify_policy(version.document) %>
 POLICY
 }


### PR DESCRIPTION
First off, thank you very much for terraforming. It has saved me many hours of work.

Currently terraforming doesn't pull the `description` field for an `iam_policy`. It appears that the call to `Aws::IAM::Client.list_policies()` returns a `nil` in the `description` for each policy object. I have reported this issue here:

https://github.com/aws/aws-sdk-ruby/issues/894

As a workaround, until the bug is fixed, this PR does an extra `Aws::IAM::Client.get_policy()` call for each policy, which _does_ return the correct `description`.

I wouldn't expect most users to have so many policies that the extra API calls are a hardship. WDYT?
