### PR TITLE
Stop including ElastiCache cluster port at any time

### DIFF
--- a/lib/terraforming/resource/elasti_cache_cluster.rb
+++ b/lib/terraforming/resource/elasti_cache_cluster.rb
@@ -30,12 +30,15 @@ module Terraforming
             "node_type" => cache_cluster.cache_node_type,
             "num_cache_nodes" => "1",
             "parameter_group_name" => cache_cluster.cache_parameter_group.cache_parameter_group_name,
-            "port" => "11211",
             "security_group_ids.#" => security_group_ids_of(cache_cluster).length.to_s,
             "security_group_names.#" => security_group_names_of(cache_cluster).length.to_s,
             "subnet_group_name" => cache_cluster.cache_subnet_group_name,
             "tags.#" => "0",
           }
+
+          attributes["port"] =
+            cache_cluster.configuration_endpoint.port.to_s if cache_cluster.configuration_endpoint
+
           resources["aws_elasticache_cluster.#{cache_cluster.cache_cluster_id}"] = {
             "type" => "aws_elasticache_cluster",
             "primary" => {

--- a/lib/terraforming/template/tf/elasti_cache_cluster.erb
+++ b/lib/terraforming/template/tf/elasti_cache_cluster.erb
@@ -6,7 +6,9 @@ resource "aws_elasticache_cluster" "<%= cache_cluster.cache_cluster_id %>" {
     node_type            = "<%= cache_cluster.cache_node_type %>"
     num_cache_nodes      = <%= cache_cluster.num_cache_nodes %>
     parameter_group_name = "<%= cache_cluster.cache_parameter_group.cache_parameter_group_name %>"
+  <%- if cache_cluster.configuration_endpoint -%>
     port                 = <%= cache_cluster.configuration_endpoint.port %>
+  <%- end -%>
   <%- if cluster_in_vpc?(cache_cluster) -%>
     subnet_group_name    = "<%= cache_cluster.cache_subnet_group_name %>"
     security_group_ids   = <%= security_group_ids_of(cache_cluster).inspect %>

--- a/spec/lib/terraforming/resource/elasti_cache_cluster_spec.rb
+++ b/spec/lib/terraforming/resource/elasti_cache_cluster_spec.rb
@@ -52,10 +52,6 @@ module Terraforming
           },
           {
             cache_cluster_id: "fuga",
-            configuration_endpoint: {
-              address: "fuga.def456.cfg.apne1.cache.amazonaws.com",
-              port: 11211
-            },
             client_download_landing_page: "https://console.aws.amazon.com/elasticache/home#client-download:",
             cache_node_type: "cache.t2.micro",
             engine: "redis",
@@ -120,7 +116,6 @@ resource "aws_elasticache_cluster" "fuga" {
     node_type            = "cache.t2.micro"
     num_cache_nodes      = 1
     parameter_group_name = "default.redis2.8"
-    port                 = 11211
     security_group_names = ["sg-hoge"]
 }
 
@@ -165,7 +160,6 @@ resource "aws_elasticache_cluster" "fuga" {
                   "node_type" => "cache.t2.micro",
                   "num_cache_nodes" => "1",
                   "parameter_group_name" => "default.redis2.8",
-                  "port" => "11211",
                   "security_group_ids.#" => "0",
                   "security_group_names.#" => "1",
                   "subnet_group_name" => "subnet-fuga",


### PR DESCRIPTION
Close #107 

## WHAT
Stop including port parameter in ElastiCache cluster at any time. It raises error with like Redis cluster.