### PR TITLE
Overwrite existing tfstate by --overwrite option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Commands:
 
 ### Export tf
 
+```bash
+$ terraforming <resource>
+```
+
 (e.g. S3 buckets):
 
 ```bash
@@ -104,7 +108,11 @@ resource "aws_s3_bucket" "fuga" {
 
 ### Export tfstate
 
-Specify `--tfstate` option (e.g. S3 buckets):
+```bash
+$ terraforming <resource> --tfstate [--merge TFSTATE_PATH] [--overwrite]
+```
+
+(e.g. S3 buckets):
 
 ```bash
 $ terraforming s3 --tfstate

--- a/README.md
+++ b/README.md
@@ -149,8 +149,7 @@ $ terraforming s3 --tfstate
 ```
 
 If you want to merge exported tfstate to existing `terraform.tfstate`, specify `--tfstate --merge=/path/to/terraform.tfstate` option.
-This option does NOT overwrite existing `terraform.tfstate`, but flush output to stdout like others.
-You should copy output in stdout by hand or `pbcopy` command, and paste it to existing `terraform.tfstate`.
+You can overwrite existing `terraform.tfstate` by specifying `--overwrite` option together.
 
 Existing `terraform.tfstate`:
 

--- a/lib/terraforming/cli.rb
+++ b/lib/terraforming/cli.rb
@@ -1,6 +1,7 @@
 module Terraforming
   class CLI < Thor
     class_option :merge, type: :string, desc: "tfstate file to merge"
+    class_option :overwrite, type: :boolean, desc: "Overwrite existng tfstate"
     class_option :tfstate, type: :boolean, desc: "Generate tfstate"
 
     desc "dbpg", "Database Parameter Group"
@@ -127,7 +128,15 @@ module Terraforming
 
     def execute(klass, options)
       result = options[:tfstate] ? tfstate(klass, options[:merge]) : tf(klass)
-      puts result
+
+      if options[:tfstate] && options[:merge] && options[:overwrite]
+        open(options[:merge], "w+") do |f|
+          f.write(result)
+          f.flush
+        end
+      else
+        puts result
+      end
     end
 
     def tf(klass)

--- a/spec/lib/terraforming/cli_spec.rb
+++ b/spec/lib/terraforming/cli_spec.rb
@@ -248,6 +248,108 @@ resource "aws_s3_bucket" "fuga" {
           }
         end
 
+        let(:initial_tfstate) do
+          {
+            "version" => 1,
+            "serial" => 1,
+            "modules" => [
+              {
+                "path" => [
+                  "root"
+                ],
+                "outputs" => {},
+                "resources" => {
+                  "aws_s3_bucket.hoge" => {
+                    "type" => "aws_s3_bucket",
+                    "primary" => {
+                      "id" => "hoge",
+                      "attributes" => {
+                        "acl" => "private",
+                        "bucket" => "hoge",
+                        "id" => "hoge"
+                      }
+                    }
+                  },
+                  "aws_s3_bucket.fuga" => {
+                    "type" => "aws_s3_bucket",
+                    "primary" => {
+                      "id" => "fuga",
+                      "attributes" => {
+                        "acl" => "private",
+                        "bucket" => "fuga",
+                        "id" => "fuga"
+                      }
+                    }
+                  },
+                }
+              }
+            ]
+          }
+        end
+
+        let(:merged_tfstate) do
+          {
+            "version" => 1,
+            "serial" => 89,
+            "remote" => {
+              "type" => "s3",
+              "config" => { "bucket" => "terraforming-tfstate", "key" => "tf" }
+            },
+            "modules" => [
+              {
+                "path" => ["root"],
+                "outputs" => {},
+                "resources" => {
+                  "aws_elb.hogehoge" => {
+                    "type" => "aws_elb",
+                    "primary" => {
+                      "id" => "hogehoge",
+                      "attributes" => {
+                        "availability_zones.#" => "2",
+                        "connection_draining" => "true",
+                        "connection_draining_timeout" => "300",
+                        "cross_zone_load_balancing" => "true",
+                        "dns_name" => "hoge-12345678.ap-northeast-1.elb.amazonaws.com",
+                        "health_check.#" => "1",
+                        "id" => "hogehoge",
+                        "idle_timeout" => "60",
+                        "instances.#" => "1",
+                        "listener.#" => "1",
+                        "name" => "hoge",
+                        "security_groups.#" => "2",
+                        "source_security_group" => "default",
+                        "subnets.#" => "2"
+                      }
+                    }
+                  },
+                  "aws_s3_bucket.hoge" => {
+                    "type" => "aws_s3_bucket",
+                    "primary" => {
+                      "id" => "hoge",
+                      "attributes" => {
+                        "acl" => "private",
+                        "bucket" => "hoge",
+                        "id" => "hoge"
+                      }
+                    }
+                  },
+                  "aws_s3_bucket.fuga" => {
+                    "type" => "aws_s3_bucket",
+                    "primary" => {
+                      "id" => "fuga",
+                      "attributes" => {
+                        "acl" => "private",
+                        "bucket" => "fuga",
+                        "id" => "fuga"
+                      }
+                    }
+                  },
+                }
+              }
+            ]
+          }
+        end
+
         before do
           allow(klass).to receive(:tf).and_return(tf)
           allow(klass).to receive(:tfstate).and_return(tfstate)
@@ -262,109 +364,33 @@ resource "aws_s3_bucket" "fuga" {
 
         context "with --tfstate" do
           it "should flush state to stdout" do
-            expect(STDOUT).to receive(:puts).with(JSON.pretty_generate({
-              "version" => 1,
-              "serial" => 1,
-              "modules" => [
-                {
-                  "path" => [
-                    "root"
-                  ],
-                  "outputs" => {},
-                  "resources" => {
-                    "aws_s3_bucket.hoge" => {
-                      "type" => "aws_s3_bucket",
-                      "primary" => {
-                        "id" => "hoge",
-                        "attributes" => {
-                          "acl" => "private",
-                          "bucket" => "hoge",
-                          "id" => "hoge"
-                        }
-                      }
-                    },
-                    "aws_s3_bucket.fuga" => {
-                      "type" => "aws_s3_bucket",
-                      "primary" => {
-                        "id" => "fuga",
-                        "attributes" => {
-                          "acl" => "private",
-                          "bucket" => "fuga",
-                          "id" => "fuga"
-                        }
-                      }
-                    },
-                  }
-                }
-              ]
-            }))
+            expect(STDOUT).to receive(:puts).with(JSON.pretty_generate(initial_tfstate))
             described_class.new.invoke(command, [], { tfstate: true })
           end
         end
 
         context "with --tfstate --merge TFSTATE" do
           it "should flush merged tfstate to stdout" do
-            expect(STDOUT).to receive(:puts).with(JSON.pretty_generate({
-              "version" => 1,
-              "serial" => 89,
-              "remote" => {
-                "type" => "s3",
-                "config" => { "bucket" => "terraforming-tfstate", "key" => "tf" }
-              },
-              "modules" => [
-                {
-                  "path" => ["root"],
-                  "outputs" => {},
-                  "resources" => {
-                    "aws_elb.hogehoge" => {
-                      "type" => "aws_elb",
-                      "primary" => {
-                        "id" => "hogehoge",
-                        "attributes" => {
-                          "availability_zones.#" => "2",
-                          "connection_draining" => "true",
-                          "connection_draining_timeout" => "300",
-                          "cross_zone_load_balancing" => "true",
-                          "dns_name" => "hoge-12345678.ap-northeast-1.elb.amazonaws.com",
-                          "health_check.#" => "1",
-                          "id" => "hogehoge",
-                          "idle_timeout" => "60",
-                          "instances.#" => "1",
-                          "listener.#" => "1",
-                          "name" => "hoge",
-                          "security_groups.#" => "2",
-                          "source_security_group" => "default",
-                          "subnets.#" => "2"
-                        }
-                      }
-                    },
-                    "aws_s3_bucket.hoge" => {
-                      "type" => "aws_s3_bucket",
-                      "primary" => {
-                        "id" => "hoge",
-                        "attributes" => {
-                          "acl" => "private",
-                          "bucket" => "hoge",
-                          "id" => "hoge"
-                        }
-                      }
-                    },
-                    "aws_s3_bucket.fuga" => {
-                      "type" => "aws_s3_bucket",
-                      "primary" => {
-                        "id" => "fuga",
-                        "attributes" => {
-                          "acl" => "private",
-                          "bucket" => "fuga",
-                          "id" => "fuga"
-                        }
-                      }
-                    },
-                  }
-                }
-              ]
-            }))
+            expect(STDOUT).to receive(:puts).with(JSON.pretty_generate(merged_tfstate))
             described_class.new.invoke(command, [], { tfstate: true, merge: tfstate_fixture_path })
+          end
+        end
+
+        context "with --tfstate --merge TFSTATE --overwrite" do
+           before do
+            @tmp_tfstate = Tempfile.new("tfstate")
+            @tmp_tfstate.write(open(tfstate_fixture_path).read)
+            @tmp_tfstate.flush
+          end
+
+          it "should overwrite passed tfstate" do
+            described_class.new.invoke(command, [], { tfstate: true, merge: @tmp_tfstate.path, overwrite: true })
+            expect(open(@tmp_tfstate.path).read).to eq JSON.pretty_generate(merged_tfstate)
+          end
+
+          after do
+            @tmp_tfstate.close
+            @tmp_tfstate.unlink
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ end
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'terraforming'
 
+require 'tempfile'
 require 'time'
 
 def fixture_path(fixture_name)


### PR DESCRIPTION
Close #113 

## WHY
Terraforming 0.1.6 does not provide the way to overwrite existing tfstate in itself. However, due to the design of shell redirect, users cannot overwrite tfstate easily.

## WHAT
Add `--overwrite` option to overwrite tfstate at once.

```bash
$ terraforming s3 --tfstate --merge .terraform/terraform.tfstate --overwrite
```