### PR TITLE
Treat Route53 hosted zone with empty delegation set

### DIFF
--- a/lib/terraforming/resource/route53_zone.rb
+++ b/lib/terraforming/resource/route53_zone.rb
@@ -57,7 +57,8 @@ module Terraforming
       end
 
       def name_servers_of(hosted_zone)
-        @client.get_hosted_zone(id: hosted_zone.id).delegation_set.name_servers
+        delegation_set = @client.get_hosted_zone(id: hosted_zone.id).delegation_set
+        delegation_set ? delegation_set.name_servers : []
       end
 
       def module_name_of(hosted_zone)

--- a/spec/lib/terraforming/resource/route53_zone_spec.rb
+++ b/spec/lib/terraforming/resource/route53_zone_spec.rb
@@ -22,7 +22,7 @@ module Terraforming
           id: "/hostedzone/OPQRSTUVWXYZAB",
           name: "fuga.net.",
           caller_reference: "ABCDEFGH-5678-IJKL-9012-MNOPQRSTUVWX",
-          config: { private_zone: false },
+          config: { private_zone: true },
           resource_record_set_count: 4
         }
       end
@@ -57,12 +57,6 @@ module Terraforming
         }
       end
 
-      let(:fuga_delegation_set) do
-        {
-          name_servers: %w(ns-5678.awsdns-12.co.uk ns-901.awsdns-34.net ns-2.awsdns-56.com ns-3456.awsdns-78.org)
-        }
-      end
-
       before do
         client.stub_responses(:list_hosted_zones,
           hosted_zones: hosted_zones, marker: "", is_truncated: false, max_items: 1)
@@ -72,7 +66,7 @@ module Terraforming
         ])
         client.stub_responses(:get_hosted_zone, [
           { hosted_zone: hoge_hosted_zone, delegation_set: hoge_delegation_set },
-          { hosted_zone: fuga_hosted_zone, delegation_set: fuga_delegation_set },
+          { hosted_zone: fuga_hosted_zone, delegation_set: nil },
         ])
       end
 
@@ -122,7 +116,7 @@ resource "aws_route53_zone" "fuga-net" {
                 "attributes"=> {
                   "id"=> "OPQRSTUVWXYZAB",
                   "name"=> "fuga.net",
-                  "name_servers.#" => "4",
+                  "name_servers.#" => "0",
                   "tags.#" => "1",
                   "zone_id" => "OPQRSTUVWXYZAB",
                 },


### PR DESCRIPTION
Close #114 

## WHY
Some Route53 _private_ hosted zones return empty delegation set. It causes nil exception at `#name_servers_of` method.

## WHAT
Return empty Array if `delegation_set` is nil