### PR TITLE
Include associated VPC parameters in Route53 hosted zone

### DIFF
--- a/lib/terraforming/resource/route53_zone.rb
+++ b/lib/terraforming/resource/route53_zone.rb
@@ -56,7 +56,7 @@ module Terraforming
       end
 
       def name_of(hosted_zone)
-        hosted_zone.name.gsub(/\.\z/, "")
+        hosted_zone.hosted_zone.name.gsub(/\.\z/, "")
       end
 
       def name_servers_of(hosted_zone)
@@ -65,7 +65,7 @@ module Terraforming
       end
 
       def module_name_of(hosted_zone)
-        normalize_module_name(name_of(hosted_zone))
+        normalize_module_name(name_of(hosted_zone)) << "-#{private_hosted_zone?(hosted_zone) ? 'private' : 'public'}"
       end
 
       def private_hosted_zone?(hosted_zone)

--- a/lib/terraforming/template/tf/route53_zone.erb
+++ b/lib/terraforming/template/tf/route53_zone.erb
@@ -1,6 +1,11 @@
 <% hosted_zones.each do |hosted_zone| -%>
 resource "aws_route53_zone" "<%= module_name_of(hosted_zone) %>" {
-    name = "<%= name_of(hosted_zone) %>"
+    name       = "<%= name_of(hosted_zone) %>"
+<%- if private_hosted_zone?(hosted_zone) -%>
+  <%- vpc = vpc_of(hosted_zone) -%>
+    vpc_id     = "<%= vpc.vpc_id %>"
+    vpc_region = "<%= vpc.vpc_region %>"
+<%- end -%>
 
     tags {
 <% tags_of(hosted_zone).each do |tag| -%>

--- a/spec/lib/terraforming/resource/route53_zone_spec.rb
+++ b/spec/lib/terraforming/resource/route53_zone_spec.rb
@@ -79,7 +79,7 @@ module Terraforming
       describe ".tf" do
         it "should generate tf" do
           expect(described_class.tf(client: client)).to eq <<-EOS
-resource "aws_route53_zone" "hoge-net" {
+resource "aws_route53_zone" "hoge-net-public" {
     name       = "hoge.net"
 
     tags {
@@ -87,7 +87,7 @@ resource "aws_route53_zone" "hoge-net" {
     }
 }
 
-resource "aws_route53_zone" "fuga-net" {
+resource "aws_route53_zone" "fuga-net-private" {
     name       = "fuga.net"
     vpc_id     = "vpc-1234abcd"
     vpc_region = "ap-northeast-1"
@@ -104,7 +104,7 @@ resource "aws_route53_zone" "fuga-net" {
       describe ".tfstate" do
         it "should generate tfstate" do
           expect(described_class.tfstate(client: client)).to eq({
-            "aws_route53_zone.hoge-net"=> {
+            "aws_route53_zone.hoge-net-public"=> {
               "type"=> "aws_route53_zone",
               "primary"=> {
                 "id"=> "ABCDEFGHIJKLMN",
@@ -119,7 +119,7 @@ resource "aws_route53_zone" "fuga-net" {
                 },
               }
             },
-            "aws_route53_zone.fuga-net"=> {
+            "aws_route53_zone.fuga-net-private"=> {
               "type"=> "aws_route53_zone",
               "primary"=> {
                 "id"=>  "OPQRSTUVWXYZAB",

--- a/spec/lib/terraforming/resource/route53_zone_spec.rb
+++ b/spec/lib/terraforming/resource/route53_zone_spec.rb
@@ -57,6 +57,12 @@ module Terraforming
         }
       end
 
+      let(:fuga_vp_cs) do
+        [
+          { vpc_region: "ap-northeast-1", vpc_id: "vpc-1234abcd" }
+        ]
+      end
+
       before do
         client.stub_responses(:list_hosted_zones,
           hosted_zones: hosted_zones, marker: "", is_truncated: false, max_items: 1)
@@ -65,8 +71,8 @@ module Terraforming
           { resource_tag_set: fuga_resource_tag_set },
         ])
         client.stub_responses(:get_hosted_zone, [
-          { hosted_zone: hoge_hosted_zone, delegation_set: hoge_delegation_set },
-          { hosted_zone: fuga_hosted_zone, delegation_set: nil },
+          { hosted_zone: hoge_hosted_zone, delegation_set: hoge_delegation_set, vp_cs: [] },
+          { hosted_zone: fuga_hosted_zone, delegation_set: nil, vp_cs: fuga_vp_cs },
         ])
       end
 
@@ -74,7 +80,7 @@ module Terraforming
         it "should generate tf" do
           expect(described_class.tf(client: client)).to eq <<-EOS
 resource "aws_route53_zone" "hoge-net" {
-    name = "hoge.net"
+    name       = "hoge.net"
 
     tags {
         "Environment" = "dev"
@@ -82,7 +88,9 @@ resource "aws_route53_zone" "hoge-net" {
 }
 
 resource "aws_route53_zone" "fuga-net" {
-    name = "fuga.net"
+    name       = "fuga.net"
+    vpc_id     = "vpc-1234abcd"
+    vpc_region = "ap-northeast-1"
 
     tags {
         "Environment" = "dev"
@@ -105,6 +113,8 @@ resource "aws_route53_zone" "fuga-net" {
                   "name"=> "hoge.net",
                   "name_servers.#" => "4",
                   "tags.#" => "1",
+                  "vpc_id" => "",
+                  "vpc_region" => "",
                   "zone_id" => "ABCDEFGHIJKLMN",
                 },
               }
@@ -118,6 +128,8 @@ resource "aws_route53_zone" "fuga-net" {
                   "name"=> "fuga.net",
                   "name_servers.#" => "0",
                   "tags.#" => "1",
+                  "vpc_id" => "vpc-1234abcd",
+                  "vpc_region" => "ap-northeast-1",
                   "zone_id" => "OPQRSTUVWXYZAB",
                 },
               }


### PR DESCRIPTION
## WHY and WHAT
Terraform v0.6.3 has `vpc_id` and `vpc_region` parameters in Route53 hosted zone.

## REF
- [AWS: aws_route53_zone - Terraform by HashiCorp](https://www.terraform.io/docs/providers/aws/r/route53_zone.html)