### PR TITLE
Exclude DB security group with empty ingress rules

### DIFF
--- a/lib/terraforming/resource/db_security_group.rb
+++ b/lib/terraforming/resource/db_security_group.rb
@@ -24,7 +24,7 @@ module Terraforming
           attributes = {
             "db_subnet_group_name" => security_group.db_security_group_name,
             "id" => security_group.db_security_group_name,
-            "ingress.#" => (security_group.ec2_security_groups.length + security_group.ip_ranges.length).to_s,
+            "ingress.#" => ingresses_of(security_group).length.to_s,
             "name" => security_group.db_security_group_name,
           }
           resources["aws_db_security_group.#{module_name_of(security_group)}"] = {
@@ -41,8 +41,12 @@ module Terraforming
 
       private
 
+      def ingresses_of(security_group)
+        security_group.ec2_security_groups + security_group.ip_ranges
+      end
+
       def db_security_groups
-        @client.describe_db_security_groups.db_security_groups
+        @client.describe_db_security_groups.db_security_groups.select { |sg| ingresses_of(sg).length > 0 }
       end
 
       def module_name_of(security_group)

--- a/spec/lib/terraforming/resource/db_security_group_spec.rb
+++ b/spec/lib/terraforming/resource/db_security_group_spec.rb
@@ -41,7 +41,14 @@ module Terraforming
               }
             ],
             db_security_group_name: "sgfoobar"
-          }
+          },
+          {
+            ip_ranges: [],
+            owner_id: "123456789012",
+            db_security_group_description: "empty",
+            ec2_security_groups: [],
+            db_security_group_name: "empty"
+          },
         ]
       end
 


### PR DESCRIPTION
Close #115 

## WHY
DB security group `ingress` parameter is _required_ parameter, however, _default_ DB security group has no ingress rule. It causes error by `terraform plan` with generated default DB security group.

## WHAT
Exclude default DB security group (= with empty ingress rules) from generating result.

## REF
- [AWS: aws_db_security_group - Terraform by HashiCorp](https://www.terraform.io/docs/providers/aws/r/db_security_group.html)
 - (It seems that document is wrong at [1d77a258](https://github.com/hashicorp/terraform/tree/1d77a258d08e9bff856d299b52a755b1250fb415) ) ...