### PR TITLE
Export buckets only in the same region

### DIFF
--- a/lib/terraforming/resource/s3.rb
+++ b/lib/terraforming/resource/s3.rb
@@ -3,7 +3,7 @@ module Terraforming
     class S3
       include Terraforming::Util
 
-      def self.tf(client: Aws::S3::Client.new(endpoint: "https://s3-ap-northeast-1.amazonaws.com"))
+      def self.tf(client: Aws::S3::Client.new)
         self.new(client).tf
       end
 

--- a/lib/terraforming/resource/s3.rb
+++ b/lib/terraforming/resource/s3.rb
@@ -3,7 +3,7 @@ module Terraforming
     class S3
       include Terraforming::Util
 
-      def self.tf(client: Aws::S3::Client.new)
+      def self.tf(client: Aws::S3::Client.new(endpoint: "https://s3-ap-northeast-1.amazonaws.com"))
         self.new(client).tf
       end
 
@@ -42,6 +42,10 @@ module Terraforming
 
       private
 
+      def bucket_location_of(bucket)
+        @client.get_bucket_location(bucket: bucket.name).location_constraint
+      end
+
       def bucket_policy_of(bucket)
         @client.get_bucket_policy(bucket: bucket.name)
       rescue Aws::S3::Errors::NoSuchBucketPolicy
@@ -49,11 +53,16 @@ module Terraforming
       end
 
       def buckets
-        @client.list_buckets.buckets
+        @client.list_buckets.buckets.select { |bucket| same_region?(bucket) }
       end
 
       def module_name_of(bucket)
         normalize_module_name(bucket.name)
+      end
+
+      def same_region?(bucket)
+        bucket_location = bucket_location_of(bucket)
+        (bucket_location == @client.config.region) || (bucket_location == "" && @client.config.region == "us-east-1")
       end
     end
   end

--- a/spec/lib/terraforming/resource/s3_spec.rb
+++ b/spec/lib/terraforming/resource/s3_spec.rb
@@ -12,12 +12,16 @@ module Terraforming
           {
             creation_date: Time.parse("2015-01-01T00:00:00.000Z"),
             name: "fuga"
+          },
+          {
+            creation_date: Time.parse("2015-01-01T00:00:00.000Z"),
+            name: "piyo"
           }
         ]
       end
 
       let(:client) do
-        Aws::S3::Client.new(stub_responses: true)
+        Aws::S3::Client.new(region: "ap-northeast-1", stub_responses: true)
       end
 
       let(:owner)  do
@@ -31,17 +35,35 @@ module Terraforming
         "{\"Version\":\"2012-10-17\",\"Id\":\"Policy123456789012\",\"Statement\":[{\"Sid\":\"Stmt123456789012\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789012:user/hoge\"},\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::hoge/*\"}]}"
       end
 
-      before do
-        client.stub_responses(:list_buckets, buckets: buckets, owner: owner)
-        client.stub_responses(:get_bucket_policy, [
-          { policy: hoge_policy },
-          "NoSuchBucketPolicy",
-        ])
+      let(:hoge_location) do
+        { location_constraint: "ap-northeast-1" }
       end
 
-      describe ".tf" do
-        it "should generate tf" do
-          expect(described_class.tf(client: client)).to eq <<-EOS
+      let(:fuga_location) do
+        { location_constraint: "ap-northeast-1" }
+      end
+
+      let(:piyo_location) do
+        { location_constraint: "" }
+      end
+
+      context "from ap-northeast-1" do
+        let(:client) do
+          Aws::S3::Client.new(region: "ap-northeast-1", stub_responses: true)
+        end
+
+        before do
+          client.stub_responses(:list_buckets, buckets: buckets, owner: owner)
+          client.stub_responses(:get_bucket_policy, [
+            { policy: hoge_policy },
+            "NoSuchBucketPolicy",
+          ])
+          client.stub_responses(:get_bucket_location, [hoge_location, fuga_location, piyo_location])
+        end
+
+        describe ".tf" do
+          it "should generate tf" do
+            expect(described_class.tf(client: client)).to eq <<-EOS
 resource "aws_s3_bucket" "hoge" {
     bucket = "hoge"
     acl    = "private"
@@ -70,39 +92,86 @@ resource "aws_s3_bucket" "fuga" {
 }
 
         EOS
+          end
+        end
+
+        describe ".tfstate" do
+          it "should generate tfstate" do
+            expect(described_class.tfstate(client: client)).to eq({
+              "aws_s3_bucket.hoge" => {
+                "type" => "aws_s3_bucket",
+                "primary" => {
+                  "id" => "hoge",
+                  "attributes" => {
+                    "acl" => "private",
+                    "bucket" => "hoge",
+                    "force_destroy" => "false",
+                    "id" => "hoge",
+                    "policy" => "{\"Version\":\"2012-10-17\",\"Id\":\"Policy123456789012\",\"Statement\":[{\"Sid\":\"Stmt123456789012\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789012:user/hoge\"},\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::hoge/*\"}]}",
+                  }
+                }
+              },
+              "aws_s3_bucket.fuga" => {
+                "type" => "aws_s3_bucket",
+                "primary" => {
+                  "id" => "fuga",
+                  "attributes" => {
+                    "acl" => "private",
+                    "bucket" => "fuga",
+                    "force_destroy" => "false",
+                    "id" => "fuga",
+                    "policy" => "",
+                  }
+                }
+              },
+            })
+          end
         end
       end
 
-      describe ".tfstate" do
-        it "should generate tfstate" do
-          expect(described_class.tfstate(client: client)).to eq({
-            "aws_s3_bucket.hoge" => {
-              "type" => "aws_s3_bucket",
-              "primary" => {
-                "id" => "hoge",
-                "attributes" => {
-                  "acl" => "private",
-                  "bucket" => "hoge",
-                  "force_destroy" => "false",
-                  "id" => "hoge",
-                  "policy" => "{\"Version\":\"2012-10-17\",\"Id\":\"Policy123456789012\",\"Statement\":[{\"Sid\":\"Stmt123456789012\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789012:user/hoge\"},\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::hoge/*\"}]}",
+      context "from us-east-1" do
+        let(:client) do
+          Aws::S3::Client.new(region: "us-east-1", stub_responses: true)
+        end
+
+        before do
+          client.stub_responses(:list_buckets, buckets: buckets, owner: owner)
+          client.stub_responses(:get_bucket_policy, [
+            "NoSuchBucketPolicy",
+          ])
+          client.stub_responses(:get_bucket_location, [hoge_location, fuga_location, piyo_location])
+        end
+
+        describe ".tf" do
+          it "should generate tf" do
+            expect(described_class.tf(client: client)).to eq <<-EOS
+resource "aws_s3_bucket" "piyo" {
+    bucket = "piyo"
+    acl    = "private"
+}
+
+        EOS
+          end
+        end
+
+        describe ".tfstate" do
+          it "should generate tfstate" do
+            expect(described_class.tfstate(client: client)).to eq({
+              "aws_s3_bucket.piyo" => {
+                "type" => "aws_s3_bucket",
+                "primary" => {
+                  "id" => "piyo",
+                  "attributes" => {
+                    "acl" => "private",
+                    "bucket" => "piyo",
+                    "force_destroy" => "false",
+                    "id" => "piyo",
+                    "policy" => "",
+                  }
                 }
-              }
-            },
-            "aws_s3_bucket.fuga" => {
-              "type" => "aws_s3_bucket",
-              "primary" => {
-                "id" => "fuga",
-                "attributes" => {
-                  "acl" => "private",
-                  "bucket" => "fuga",
-                  "force_destroy" => "false",
-                  "id" => "fuga",
-                  "policy" => "",
-                }
-              }
-            },
-          })
+              },
+            })
+          end
         end
       end
     end

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 2.1.0"
+  spec.add_dependency "aws-sdk", "~> 2.1.15"
   spec.add_dependency "oj"
   spec.add_dependency "ox"
   spec.add_dependency "thor"


### PR DESCRIPTION
Close #116 

## WHY
Terraforming v0.1.6 tries to fetch S3 buckets in the different region from `AWS_REGION`, and it fails.

## WHAT
Export S3 buckets only in the same region as `AWS_REGION`.

## TODO
- [x] Update required version of aws-sdk-ruby
 - https://github.com/aws/aws-sdk-ruby/pull/899