### PR TITLE
Normalize module name of IAM user

### DIFF
--- a/lib/terraforming/resource/iam_user.rb
+++ b/lib/terraforming/resource/iam_user.rb
@@ -28,7 +28,7 @@ module Terraforming
             "path" => user.path,
             "unique_id" => user.user_id,
           }
-          resources["aws_iam_user.#{user.user_name}"] = {
+          resources["aws_iam_user.#{module_name_of(user)}"] = {
             "type" => "aws_iam_user",
             "primary" => {
               "id" => user.user_name,
@@ -44,6 +44,10 @@ module Terraforming
 
       def iam_users
         @client.list_users.users
+      end
+
+      def module_name_of(user)
+        normalize_module_name(user.user_name)
       end
     end
   end

--- a/lib/terraforming/template/tf/iam_user.erb
+++ b/lib/terraforming/template/tf/iam_user.erb
@@ -1,5 +1,5 @@
 <% iam_users.each do |user| -%>
-resource "aws_iam_user" "<%= user.user_name %>" {
+resource "aws_iam_user" "<%= module_name_of(user) %>" {
     name = "<%= user.user_name %>"
     path = "<%= user.path %>"
 }

--- a/spec/lib/terraforming/resource/iam_user_spec.rb
+++ b/spec/lib/terraforming/resource/iam_user_spec.rb
@@ -19,7 +19,7 @@ module Terraforming
           },
           {
             path: "/system/",
-            user_name: "fuga",
+            user_name: "fuga.piyo",
             user_id: "OPQRSTUVWXYZA8901234",
             arn: "arn:aws:iam::345678901234:user/fuga",
             create_date: Time.parse("2015-05-01 12:34:56 UTC"),
@@ -40,8 +40,8 @@ resource "aws_iam_user" "hoge" {
     path = "/"
 }
 
-resource "aws_iam_user" "fuga" {
-    name = "fuga"
+resource "aws_iam_user" "fuga-piyo" {
+    name = "fuga.piyo"
     path = "/system/"
 }
 
@@ -65,14 +65,14 @@ resource "aws_iam_user" "fuga" {
                 }
               }
             },
-            "aws_iam_user.fuga" => {
+            "aws_iam_user.fuga-piyo" => {
               "type" => "aws_iam_user",
               "primary" => {
-                "id" => "fuga",
+                "id" => "fuga.piyo",
                 "attributes" => {
                   "arn"=> "arn:aws:iam::345678901234:user/fuga",
-                  "id" => "fuga",
-                  "name" => "fuga",
+                  "id" => "fuga.piyo",
+                  "name" => "fuga.piyo",
                   "path" => "/system/",
                   "unique_id" => "OPQRSTUVWXYZA8901234",
                 }


### PR DESCRIPTION
Close #123 

## WHY
Terraform does not allow module name with `.` (dots), like below.

```
resource "aws_iam_user" "david.raistrick" {
    name = "david.raistrick"
    path = "/"
}
```

## WHAT
Replace dots to hyphen in IAM user module

```
resource "aws_iam_user" "david-raistrick" {
    name = "david.raistrick"
    path = "/"
}
```