### PR TITLE
Export ec2 instance monitoring state

### DIFF
--- a/lib/terraforming/resource/ec2.rb
+++ b/lib/terraforming/resource/ec2.rb
@@ -94,7 +94,7 @@ module Terraforming
       end
 
       def monitoring_state(instance)
-        instance.monitoring.state == "enabled" ? 1 : 0
+        %w(enabled pending).include?(instance.monitoring.state)
       end
 
       def instances

--- a/lib/terraforming/resource/ec2.rb
+++ b/lib/terraforming/resource/ec2.rb
@@ -33,6 +33,7 @@ module Terraforming
             "ephemeral_block_device.#" => "0", # Terraform 0.6.1 cannot fetch this field from AWS
             "id"=> instance.instance_id,
             "instance_type"=> instance.instance_type,
+            "monitoring" => monitoring_state(instance).to_s,
             "private_dns"=> instance.private_dns_name,
             "private_ip"=> instance.private_ip_address,
             "public_dns"=> instance.public_dns_name,
@@ -90,6 +91,10 @@ module Terraforming
       def in_vpc?(instance)
         vpc_security_groups_of(instance).length > 0 ||
           (instance.subnet_id && instance.subnet_id != "" && instance.security_groups.length == 0)
+      end
+
+      def monitoring_state(instance)
+        instance.monitoring.state == "enabled" ? 1 : 0
       end
 
       def instances

--- a/lib/terraforming/template/tf/ec2.erb
+++ b/lib/terraforming/template/tf/ec2.erb
@@ -4,7 +4,7 @@ resource "aws_instance" "<%= module_name_of(instance) %>" {
     availability_zone           = "<%= instance.placement.availability_zone %>"
     ebs_optimized               = <%= instance.ebs_optimized %>
     instance_type               = "<%= instance.instance_type %>"
-    monitoring                  = <%= monitoring_state(instance) == 1 %>
+    monitoring                  = <%= monitoring_state(instance) %>
     key_name                    = "<%= instance.key_name %>"
 <%- if in_vpc?(instance) -%>
     subnet_id                   = "<%= instance.subnet_id %>"

--- a/lib/terraforming/template/tf/ec2.erb
+++ b/lib/terraforming/template/tf/ec2.erb
@@ -4,6 +4,7 @@ resource "aws_instance" "<%= module_name_of(instance) %>" {
     availability_zone           = "<%= instance.placement.availability_zone %>"
     ebs_optimized               = <%= instance.ebs_optimized %>
     instance_type               = "<%= instance.instance_type %>"
+    monitoring                  = <%= monitoring_state(instance) == 1 %>
     key_name                    = "<%= instance.key_name %>"
 <%- if in_vpc?(instance) -%>
     subnet_id                   = "<%= instance.subnet_id %>"

--- a/spec/lib/terraforming/resource/ec2_spec.rb
+++ b/spec/lib/terraforming/resource/ec2_spec.rb
@@ -20,9 +20,9 @@ module Terraforming
             ami_launch_index: 0,
             product_codes: [],
             instance_type: "t2.micro",
+            monitoring: { state: "disabled" },
             launch_time: Time.parse("2015-03-12 01:23:45 UTC"),
             placement: { availability_zone: "ap-northeast-1b", group_name: "", tenancy: "default" },
-            monitoring: { state: "disabled" },
             subnet_id: "subnet-1234abcd",
             vpc_id: "vpc-1234abcd",
             private_ip_address: "10.0.0.100",
@@ -103,9 +103,9 @@ module Terraforming
             ami_launch_index: 0,
             product_codes: [],
             instance_type: "t2.micro",
+            monitoring: { state: "enabled" },
             launch_time: Time.parse("2015-03-12 01:23:45 UTC"),
             placement: { availability_zone: "ap-northeast-1b", group_name: "", tenancy: "default" },
-            monitoring: { state: "disabled" },
             subnet_id: "",
             vpc_id: "vpc-5678efgh",
             private_ip_address: "10.0.0.101",
@@ -184,9 +184,9 @@ module Terraforming
             ami_launch_index: 0,
             product_codes: [],
             instance_type: "t2.micro",
+            monitoring: { state: "pending" },
             launch_time: Time.parse("2015-03-12 01:23:45 UTC"),
             placement: { availability_zone: "ap-northeast-1b", group_name: "", tenancy: "default" },
-            monitoring: { state: "disabled" },
             subnet_id: "",
             vpc_id: "vpc-9012ijkl",
             private_ip_address: "10.0.0.102",
@@ -324,6 +324,7 @@ resource "aws_instance" "hoge" {
     availability_zone           = "ap-northeast-1b"
     ebs_optimized               = false
     instance_type               = "t2.micro"
+    monitoring                  = false
     key_name                    = "hoge-key"
     subnet_id                   = "subnet-1234abcd"
     vpc_security_group_ids      = ["sg-1234abcd"]
@@ -348,6 +349,7 @@ resource "aws_instance" "i-5678efgh" {
     availability_zone           = "ap-northeast-1b"
     ebs_optimized               = false
     instance_type               = "t2.micro"
+    monitoring                  = true
     key_name                    = "hoge-key"
     security_groups             = ["default"]
     associate_public_ip_address = true
@@ -372,6 +374,7 @@ resource "aws_instance" "i-9012ijkl" {
     availability_zone           = "ap-northeast-1b"
     ebs_optimized               = false
     instance_type               = "t2.micro"
+    monitoring                  = false
     key_name                    = "hoge-key"
     security_groups             = ["default"]
     associate_public_ip_address = true
@@ -402,6 +405,7 @@ resource "aws_instance" "i-9012ijkl" {
                   "ephemeral_block_device.#" => "0",
                   "id" => "i-1234abcd",
                   "instance_type" => "t2.micro",
+                  "monitoring" => "0",
                   "private_dns" => "ip-10-0-0-100.ap-northeast-1.compute.internal",
                   "private_ip" => "10.0.0.100",
                   "public_dns" => "ec2-54-12-0-0.ap-northeast-1.compute.amazonaws.com",
@@ -431,6 +435,7 @@ resource "aws_instance" "i-9012ijkl" {
                   "ephemeral_block_device.#" => "0",
                   "id" => "i-5678efgh",
                   "instance_type" => "t2.micro",
+                  "monitoring" => "1",
                   "private_dns" => "ip-10-0-0-101.ap-northeast-1.compute.internal",
                   "private_ip" => "10.0.0.101",
                   "public_dns" => "ec2-54-12-0-1.ap-northeast-1.compute.amazonaws.com",
@@ -459,6 +464,7 @@ resource "aws_instance" "i-9012ijkl" {
                   "ephemeral_block_device.#" => "0",
                   "id" => "i-9012ijkl",
                   "instance_type" => "t2.micro",
+                  "monitoring" => "0",
                   "private_dns" => "ip-10-0-0-102.ap-northeast-1.compute.internal",
                   "private_ip" => "10.0.0.102",
                   "public_dns" => "ec2-54-12-0-2.ap-northeast-1.compute.amazonaws.com",

--- a/spec/lib/terraforming/resource/ec2_spec.rb
+++ b/spec/lib/terraforming/resource/ec2_spec.rb
@@ -374,7 +374,7 @@ resource "aws_instance" "i-9012ijkl" {
     availability_zone           = "ap-northeast-1b"
     ebs_optimized               = false
     instance_type               = "t2.micro"
-    monitoring                  = false
+    monitoring                  = true
     key_name                    = "hoge-key"
     security_groups             = ["default"]
     associate_public_ip_address = true
@@ -405,7 +405,7 @@ resource "aws_instance" "i-9012ijkl" {
                   "ephemeral_block_device.#" => "0",
                   "id" => "i-1234abcd",
                   "instance_type" => "t2.micro",
-                  "monitoring" => "0",
+                  "monitoring" => "false",
                   "private_dns" => "ip-10-0-0-100.ap-northeast-1.compute.internal",
                   "private_ip" => "10.0.0.100",
                   "public_dns" => "ec2-54-12-0-0.ap-northeast-1.compute.amazonaws.com",
@@ -435,7 +435,7 @@ resource "aws_instance" "i-9012ijkl" {
                   "ephemeral_block_device.#" => "0",
                   "id" => "i-5678efgh",
                   "instance_type" => "t2.micro",
-                  "monitoring" => "1",
+                  "monitoring" => "true",
                   "private_dns" => "ip-10-0-0-101.ap-northeast-1.compute.internal",
                   "private_ip" => "10.0.0.101",
                   "public_dns" => "ec2-54-12-0-1.ap-northeast-1.compute.amazonaws.com",
@@ -464,7 +464,7 @@ resource "aws_instance" "i-9012ijkl" {
                   "ephemeral_block_device.#" => "0",
                   "id" => "i-9012ijkl",
                   "instance_type" => "t2.micro",
-                  "monitoring" => "0",
+                  "monitoring" => "true",
                   "private_dns" => "ip-10-0-0-102.ap-northeast-1.compute.internal",
                   "private_ip" => "10.0.0.102",
                   "public_dns" => "ec2-54-12-0-2.ap-northeast-1.compute.amazonaws.com",


### PR DESCRIPTION
Hi,

I added a missing key `monitoring` for `ec2` resource.

The state of the API response could be `disabled`, `disabling`, `enabled`, `pending`.

I implemented this to output `monitoring  = true` only for `enabled` state.

refs:

- http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Types/Monitoring.html
- https://www.terraform.io/docs/providers/aws/r/instance.html#monitoring