### PR TITLE
Exclude iops if device type is standard

### DIFF
--- a/lib/terraforming/template/tf/ec2.erb
+++ b/lib/terraforming/template/tf/ec2.erb
@@ -22,7 +22,9 @@ resource "aws_instance" "<%= module_name_of(instance) %>" {
     root_block_device {
         volume_type           = "<%= block_device.volume_type %>"
         volume_size           = <%= block_device.size %>
+<%- if block_device.iops -%>
         iops                  = <%= block_device.iops %>
+<%- end -%>
         delete_on_termination = <%= mapping.ebs.delete_on_termination %>
     }
 <%- else -%>
@@ -31,7 +33,9 @@ resource "aws_instance" "<%= module_name_of(instance) %>" {
         snapshot_id           = "<%= block_device.snapshot_id %>"
         volume_type           = "<%= block_device.volume_type %>"
         volume_size           = <%= block_device.size %>
+<%- if block_device.iops -%>
         iops                  = <%= block_device.iops %>
+<%- end -%>
         delete_on_termination = <%= mapping.ebs.delete_on_termination %>
     }
 <% end -%>

--- a/spec/lib/terraforming/resource/ec2_spec.rb
+++ b/spec/lib/terraforming/resource/ec2_spec.rb
@@ -278,8 +278,7 @@ module Terraforming
                 delete_on_termination: true
               }
             ],
-            volume_type: "gp2",
-            iops: 24,
+            volume_type: "standard",
             encrypted: false
           }
         ]
@@ -333,9 +332,8 @@ resource "aws_instance" "hoge" {
     source_dest_check           = true
 
     root_block_device {
-        volume_type           = "gp2"
+        volume_type           = "standard"
         volume_size           = 8
-        iops                  = 24
         delete_on_termination = true
     }
 


### PR DESCRIPTION
Close #131 

## WHAT
Exclude `iops` field from EC2 instance tf when the device is `standard` type (= does not have `iops` parameter in itself)