### PR TITLE
Pass in aws profile name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.projectile

--- a/lib/terraforming.rb
+++ b/lib/terraforming.rb
@@ -6,6 +6,8 @@ require "erb"
 require "json"
 require "thor"
 require "zlib"
+require 'inifile'
+
 
 require "terraforming/util"
 require "terraforming/version"

--- a/lib/terraforming/cli.rb
+++ b/lib/terraforming/cli.rb
@@ -3,6 +3,7 @@ module Terraforming
     class_option :merge, type: :string, desc: "tfstate file to merge"
     class_option :overwrite, type: :boolean, desc: "Overwrite existng tfstate"
     class_option :tfstate, type: :boolean, desc: "Generate tfstate"
+    class_option :profile, type: :string, desc: "Aws profile name from ~/.aws/credentials"
 
     desc "dbpg", "Database Parameter Group"
     def dbpg
@@ -137,6 +138,14 @@ module Terraforming
     private
 
     def execute(klass, options)
+
+      if options[:profile]
+        profile_map = IniFile.load(File.expand_path("~/.aws/credentials")).to_h[options[:profile].to_s]
+        profile_map.each do |k, v|
+          ENV[k.upcase] = v
+        end
+      end
+
       result = options[:tfstate] ? tfstate(klass, options[:merge]) : tf(klass)
 
       if options[:tfstate] && options[:merge] && options[:overwrite]

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "oj"
   spec.add_dependency "ox"
   spec.add_dependency "thor"
+  spec.add_dependency "inifile"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "codeclimate-test-reporter"


### PR DESCRIPTION
The name should conform to what is in your ~/.aws/credentials file. For example,
with these changes, this works as expected:

    $ cat ~/.aws/credentials
    [amazon_account_name]
    aws_access_key_id = Foo
    aws_secret_access_key = BarBarBar

    $ bundle
    # ...
    # Note, if you have a `aws_region` record in ~/.aws/creds, that should be picked up too.

    $ AWS_REGION=us-east-1 bundle exec bin/terraforming elb --profile amazon_account_name

    #...
    #...
    # specific amazon_account_name information.

/cc @ericfode 