### PR TITLE
Use the .new method on MultiFormatter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 require "codeclimate-test-reporter"
 
 SimpleCov.start do
-  formatter SimpleCov::Formatter::MultiFormatter[
+  formatter SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
     CodeClimate::TestReporter::Formatter,
-  ]
+  ])
 end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)


### PR DESCRIPTION
Fixes 'multi_formatter.rb:17:in `new': wrong number of arguments (2 for 0..1) (ArgumentError)' error when running 'bundle exec rake'.