### PR TITLE
Improved route_table support

### DIFF
--- a/lib/terraforming/resource/route_table.rb
+++ b/lib/terraforming/resource/route_table.rb
@@ -90,14 +90,14 @@ module Terraforming
 
         instance_set = false
         if route.instance_id != ''
-          string += route.instance_id.to_s
+          string << route.instance_id.to_s
           instance_set = true
         end
 
-        string += route.vpc_peering_connection_id.to_s
+        string << route.vpc_peering_connection_id.to_s
 
         unless instance_set
-          string += route.network_interface_id.to_s
+          string << route.network_interface_id.to_s
         end
 
         Zlib.crc32(string)
@@ -125,7 +125,6 @@ module Terraforming
         tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
         attributes
       end
-
     end
   end
 end

--- a/lib/terraforming/template/tf/route_table.erb
+++ b/lib/terraforming/template/tf/route_table.erb
@@ -22,6 +22,7 @@ resource "aws_route_table" "<%= module_name_of(route_table) %>" {
 <% end -%>
 <% if route_table.propagating_vgws.any? -%>
     propagating_vgws = <%= propagaving_vgws_of(route_table).inspect %>
+
 <% end -%>
     tags {
 <% route_table.tags.each do |tag| -%>

--- a/lib/terraforming/template/tf/route_table.erb
+++ b/lib/terraforming/template/tf/route_table.erb
@@ -20,6 +20,9 @@ resource "aws_route_table" "<%= module_name_of(route_table) %>" {
     }
 
 <% end -%>
+<% if route_table.propagating_vgws.any? -%>
+    propagating_vgws = <%= propagaving_vgws_of(route_table).inspect %>
+<% end -%>
     tags {
 <% route_table.tags.each do |tag| -%>
         "<%= tag.key %>" = "<%= tag.value %>"

--- a/spec/lib/terraforming/resource/route_table_spec.rb
+++ b/spec/lib/terraforming/resource/route_table_spec.rb
@@ -68,6 +68,9 @@ module Terraforming
                 main: false
               }
             ],
+            propagating_vgws: [
+              { gateway_id: 'vgw-1a4j20b' }
+            ],
             tags: [
               {
                 key: 'Name',
@@ -148,6 +151,8 @@ resource "aws_route_table" "my-route-table" {
         vpc_peering_connection_id = "pcx-c56789de"
     }
 
+    propagating_vgws = ["vgw-1a4j20b"]
+
     tags {
         "Name" = "my-route-table"
     }
@@ -203,7 +208,8 @@ resource "aws_route_table" "my-route-table-2" {
                   "route.2351420441.network_interface_id" => "",
                   "route.2351420441.vpc_peering_connection_id" => "pcx-c56789de",
 
-                  "propagating_vgws.#" => "0"
+                  "propagating_vgws.#" => "1",
+                  "propagating_vgws.772379535" => "vgw-1a4j20b"
                 }
               }
             },

--- a/spec/lib/terraforming/resource/route_table_spec.rb
+++ b/spec/lib/terraforming/resource/route_table_spec.rb
@@ -88,7 +88,28 @@ module Terraforming
                 network_interface_id: nil,
                 vpc_peering_connection_id: nil,
                 state: 'active'
-              }
+              },
+              {
+                destination_cidr_block: '172.18.0.0/16',
+                destination_prefix_list_id: nil,
+                gateway_id: 'vgw-2345dddf',
+                instance_id: nil,
+                instance_owner_id: nil,
+                network_interface_id: nil,
+                vpc_peering_connection_id: nil,
+                state: 'active',
+                origin: 'EnableVgwRoutePropagation'
+              },
+              {
+                destination_cidr_block: '10.18.0.0/16',
+                destination_prefix_list_id: '1234567',
+                gateway_id: 'vgw-2115dddf',
+                instance_id: nil,
+                instance_owner_id: nil,
+                network_interface_id: nil,
+                vpc_peering_connection_id: nil,
+                state: 'active'
+              },
             ],
             associations: [
             ],
@@ -111,11 +132,6 @@ module Terraforming
           expect(described_class.tf(client: client)).to eq <<-EOS
 resource "aws_route_table" "my-route-table" {
     vpc_id     = "vpc-ab123cde"
-
-    route {
-        cidr_block = "10.0.0.0/16"
-        gateway_id = "local"
-    }
 
     route {
         cidr_block = "0.0.0.0/0"
@@ -163,9 +179,31 @@ resource "aws_route_table" "my-route-table-2" {
                 "id" => "rtb-a12bcd34",
                 "attributes" => {
                   "id" => "rtb-a12bcd34",
-                  "route.#" => "4",
-                  "tags.#" => "1",
                   "vpc_id" => "vpc-ab123cde",
+
+                  "tags.#" => "1",
+                  "tags.Name"=>"my-route-table",
+
+                  "route.#" => "3",
+                  "route.4066406027.cidr_block" => "0.0.0.0/0",
+                  "route.4066406027.gateway_id" => "igw-1ab2345c",
+                  "route.4066406027.instance_id" => "",
+                  "route.4066406027.network_interface_id" => "",
+                  "route.4066406027.vpc_peering_connection_id" => "",
+
+                  "route.3686469914.cidr_block" => "192.168.1.0/24",
+                  "route.3686469914.gateway_id" => "",
+                  "route.3686469914.instance_id" => "i-ec12345a",
+                  "route.3686469914.network_interface_id" => "",
+                  "route.3686469914.vpc_peering_connection_id" => "",
+
+                  "route.2351420441.cidr_block" => "192.168.2.0/24",
+                  "route.2351420441.gateway_id" => "",
+                  "route.2351420441.instance_id" => "",
+                  "route.2351420441.network_interface_id" => "",
+                  "route.2351420441.vpc_peering_connection_id" => "pcx-c56789de",
+
+                  "propagating_vgws.#" => "0"
                 }
               }
             },
@@ -175,9 +213,19 @@ resource "aws_route_table" "my-route-table-2" {
                 "id"=>"rtb-efgh5678",
                 "attributes" => {
                   "id" => "rtb-efgh5678",
-                  "route.#" => "1",
+                  "vpc_id" => "vpc-ab123cde",
+
                   "tags.#" => "1",
-                  "vpc_id" => "vpc-ab123cde"
+                  "tags.Name"=>"my-route-table-2",
+
+                  "route.#" => "1",
+                  "route.4031521715.cidr_block" => "0.0.0.0/0",
+                  "route.4031521715.gateway_id" => "vgw-2345cdef",
+                  "route.4031521715.instance_id" => "",
+                  "route.4031521715.network_interface_id" => "",
+                  "route.4031521715.vpc_peering_connection_id" => "",
+
+                  "propagating_vgws.#" => "0",
                 }
               }
             }


### PR DESCRIPTION
As mentioned in #145, current route_table support is incomplete and incorrect:
* it does not support tags in TF state
* it does not support routes in TF state
* it does not support propagating virtual gateways at all
* it exports routes that should not be exported (local gateway id and a few other cases)

This PR has been tested on a relatively large account and it seems to have worked correctly: we have exported a few dozen networks across 5 VPCs with exported routes, etc. And, based on the live experience with the new code, I have updated route_table specs to actually expect correct results as well.