### PR TITLE
Skip implicit route table associations when generating tfstate

### DIFF
--- a/lib/terraforming/resource/route_table_association.rb
+++ b/lib/terraforming/resource/route_table_association.rb
@@ -23,11 +23,15 @@ module Terraforming
         resources = {}
         route_tables.each do |route_table|
           associations_of(route_table).each do |assoc|
+            # Skip implicit associations
+            next unless assoc.subnet_id
+
             attributes = {
               "id" => assoc.route_table_association_id,
               "route_table_id" => assoc.route_table_id,
               "subnet_id" => assoc.subnet_id,
             }
+
             resources["aws_route_table_association.#{module_name_of(route_table, assoc)}"] = {
               "type" => "aws_route_table_association",
               "primary" => {

--- a/lib/terraforming/resource/route_table_association.rb
+++ b/lib/terraforming/resource/route_table_association.rb
@@ -23,9 +23,6 @@ module Terraforming
         resources = {}
         route_tables.each do |route_table|
           associations_of(route_table).each do |assoc|
-            # Skip implicit associations
-            next unless assoc.subnet_id
-
             attributes = {
               "id" => assoc.route_table_association_id,
               "route_table_id" => assoc.route_table_id,
@@ -47,7 +44,7 @@ module Terraforming
       private
 
       def associations_of(route_table)
-        route_table.associations
+        route_table.associations.reject { |association| association.subnet_id.nil? }
       end
 
       def module_name_of(route_table, assoc)

--- a/lib/terraforming/template/tf/route_table_association.erb
+++ b/lib/terraforming/template/tf/route_table_association.erb
@@ -1,11 +1,9 @@
 <% route_tables.each do |route_table| -%>
 <% associations_of(route_table).each do |assoc| -%>
-<% if assoc.subnet_id -%>
 resource "aws_route_table_association" "<%= module_name_of(route_table, assoc) %>" {
     route_table_id = "<%= assoc.route_table_id %>"
     subnet_id = "<%= assoc.subnet_id %>"
 }
 
-<% end -%>
 <% end -%>
 <% end -%>

--- a/spec/lib/terraforming/resource/route_table_association_spec.rb
+++ b/spec/lib/terraforming/resource/route_table_association_spec.rb
@@ -66,6 +66,12 @@ module Terraforming
                 route_table_id: 'rtb-a12bcd34',
                 subnet_id: 'subnet-8901b123',
                 main: false
+              },
+              {
+                route_table_association_id: 'rtbassoc-e71201aaa',
+                route_table_id: 'rtb-a12bcd34',
+                subnet_id: nil,
+                main: true
               }
             ],
             tags: [


### PR DESCRIPTION
As explained in #147, there is a way for terraforming to generate tfstate for tfa that would cause terraform to crash. This PR fixes the issue.