### PR TITLE
Use aws-sdk v2.2.5

### DIFF
--- a/spec/lib/terraforming/resource/auto_scaling_group_spec.rb
+++ b/spec/lib/terraforming/resource/auto_scaling_group_spec.rb
@@ -29,14 +29,16 @@ module Terraforming
                 availability_zone: "ap-northeast-1b",
                 lifecycle_state: "InService",
                 health_status: "Healthy",
-                launch_configuration_name: "hoge-lc"
+                launch_configuration_name: "hoge-lc",
+                protected_from_scale_in: true,
               },
               {
                 instance_id: "i-5678efgh",
                 availability_zone: "ap-northeast-1b",
                 lifecycle_state: "InService",
                 health_status: "Healthy",
-                launch_configuration_name: "hoge-lc"
+                launch_configuration_name: "hoge-lc",
+                protected_from_scale_in: true,
               },
             ],
             created_time: Time.parse("2015-10-21 04:08:39 UTC"),
@@ -73,14 +75,16 @@ module Terraforming
                 availability_zone: "ap-northeast-1c",
                 lifecycle_state: "InService",
                 health_status: "Healthy",
-                launch_configuration_name: "fuga-lc"
+                launch_configuration_name: "fuga-lc",
+                protected_from_scale_in: true,
               },
               {
                 instance_id: "i-3456mnop",
                 availability_zone: "ap-northeast-1c",
                 lifecycle_state: "InService",
                 health_status: "Healthy",
-                launch_configuration_name: "fuga-lc"
+                launch_configuration_name: "fuga-lc",
+                protected_from_scale_in: true,
               },
             ],
             created_time: Time.parse("2015-10-20 04:08:39 UTC"),

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 2.2.0"
+  spec.add_dependency "aws-sdk", "= 2.2.5"
   spec.add_dependency "oj"
   spec.add_dependency "ox"
   spec.add_dependency "thor"


### PR DESCRIPTION
To avoid unexpected test failures due to the new version of aws-sdk, we decided to fix the version fo aws-sdk.