### PR TITLE
Modify AutoScaling Group tags

### DIFF
--- a/lib/terraforming/template/tf/auto_scaling_group.erb
+++ b/lib/terraforming/template/tf/auto_scaling_group.erb
@@ -15,13 +15,14 @@ resource "aws_autoscaling_group" "<%= module_name_of(group) %>" {
     vpc_zone_identifier       = <%= vpc_zone_identifier_of(group).inspect %>
 <%- end -%>
 
-    tag {
 <% group.tags.each do |tag| -%>
+    tag {
         key   = "<%= tag.key %>"
         value = "<%= tag.value %>"
         propagate_at_launch = <%= tag.propagate_at_launch.to_s %>
-<% end -%>
     }
+
+<% end -%>
 }
 
 <% end -%>

--- a/spec/lib/terraforming/resource/auto_scaling_group_spec.rb
+++ b/spec/lib/terraforming/resource/auto_scaling_group_spec.rb
@@ -94,6 +94,51 @@ module Terraforming
             tags: [],
             termination_policies: ["Default"],
           },
+          {
+            auto_scaling_group_name: "piyo",
+            auto_scaling_group_arn:
+            "arn:aws:autoscaling:ap-northeast-1:123456789012:autoScalingGroup:1234abcd-1dd4-4089-b8c9-12345abcdefg:autoScalingGroupName/piyo",
+            launch_configuration_name: "piyo-lc",
+            min_size: 1,
+            max_size: 2,
+            desired_capacity: 1,
+            default_cooldown: 300,
+            availability_zones: ["ap-northeast-1c"],
+            load_balancer_names: [],
+            health_check_type: "EC2",
+            health_check_grace_period: 300,
+            instances: [
+              {
+                instance_id: "i-7890qrst",
+                availability_zone: "ap-northeast-1c",
+                lifecycle_state: "InService",
+                health_status: "Healthy",
+                launch_configuration_name: "piyo-lc",
+                protected_from_scale_in: true,
+              },
+            ],
+            created_time: Time.parse("2015-10-20 04:08:39 UTC"),
+            suspended_processes: [],
+            vpc_zone_identifier: "subnet-1234abcd,subnet-5678efgh",
+            enabled_metrics: [],
+            tags: [
+              {
+                resource_id: "piyo",
+                resource_type: "auto-scaling-group",
+                key: "foo1",
+                value: "bar",
+                propagate_at_launch: true,
+              },
+              {
+                resource_id: "piyo",
+                resource_type: "auto-scaling-group",
+                key: "app",
+                value: "sample",
+                propagate_at_launch: true,
+              }
+            ],
+            termination_policies: ["Default"],
+          },
         ]
       end
 
@@ -119,6 +164,7 @@ resource "aws_autoscaling_group" "hoge" {
         value = "bar"
         propagate_at_launch = true
     }
+
 }
 
 resource "aws_autoscaling_group" "fuga" {
@@ -131,8 +177,30 @@ resource "aws_autoscaling_group" "fuga" {
     name                      = "fuga"
     vpc_zone_identifier       = ["subnet-1234abcd", "subnet-5678efgh"]
 
+}
+
+resource "aws_autoscaling_group" "piyo" {
+    desired_capacity          = 1
+    health_check_grace_period = 300
+    health_check_type         = "EC2"
+    launch_configuration      = "piyo-lc"
+    max_size                  = 2
+    min_size                  = 1
+    name                      = "piyo"
+    vpc_zone_identifier       = ["subnet-1234abcd", "subnet-5678efgh"]
+
     tag {
+        key   = "foo1"
+        value = "bar"
+        propagate_at_launch = true
     }
+
+    tag {
+        key   = "app"
+        value = "sample"
+        propagate_at_launch = true
+    }
+
 }
 
         EOS
@@ -140,7 +208,7 @@ resource "aws_autoscaling_group" "fuga" {
       end
 
       describe ".tfstate" do
-        it "should generate tfstate" do
+        xit "should generate tfstate" do
           expect(described_class.tfstate(client: client)).to eq({
             "aws_autoscaling_group.hoge" => {
               "type" => "aws_autoscaling_group",

--- a/spec/lib/terraforming/resource/auto_scaling_group_spec.rb
+++ b/spec/lib/terraforming/resource/auto_scaling_group_spec.rb
@@ -208,7 +208,7 @@ resource "aws_autoscaling_group" "piyo" {
       end
 
       describe ".tfstate" do
-        xit "should generate tfstate" do
+        it "should generate tfstate" do
           expect(described_class.tfstate(client: client)).to eq({
             "aws_autoscaling_group.hoge" => {
               "type" => "aws_autoscaling_group",
@@ -255,6 +255,37 @@ resource "aws_autoscaling_group" "piyo" {
                   "min_size" => "1",
                   "name" => "fuga",
                   "tag.#" => "0",
+                  "termination_policies.#" => "0",
+                  "vpc_zone_identifier.#" => "2",
+                },
+                "meta" => {
+                  "schema_version" => "1"
+                }
+              }
+            },
+            "aws_autoscaling_group.piyo" => {
+              "type" => "aws_autoscaling_group",
+              "primary" => {
+                "id" => "piyo",
+                "attributes" => {
+                  "availability_zones.#" => "0",
+                  "default_cooldown" => "300",
+                  "desired_capacity" => "1",
+                  "health_check_grace_period" => "300",
+                  "health_check_type" => "EC2",
+                  "id" => "piyo",
+                  "launch_configuration" => "piyo-lc",
+                  "load_balancers.#" => "0",
+                  "max_size" => "2",
+                  "min_size" => "1",
+                  "name" => "piyo",
+                  "tag.#" => "2",
+                  "tag.3921462319.key" => "foo1",
+                  "tag.3921462319.propagate_at_launch" => "true",
+                  "tag.3921462319.value" => "bar",
+                  "tag.1379189922.key" => "app",
+                  "tag.1379189922.propagate_at_launch" => "true",
+                  "tag.1379189922.value" => "sample",
                   "termination_policies.#" => "0",
                   "vpc_zone_identifier.#" => "2",
                 },


### PR DESCRIPTION
## WHY
Multiple tags in AutoScaling Group are exported to this tf:

```
  tag {
        key   = "Name"
        value = "piyo"
        propagate_at_launch = true
        key   = "app"
        value = "sample"
        propagate_at_launch = true
    }
```

These should be exported like this:

```
  tag {
        key   = "Name"
        value = "piyo"
        propagate_at_launch = true
  }

  tag {
        key   = "app"
        value = "sample"
        propagate_at_launch = true
    }
```

## WHAT
Modify code, and add test fixture and tests .