### PR TITLE
Adding security_group in the case of multiple items with one "self"

### DIFF
--- a/lib/terraforming/template/tf/security_group.erb
+++ b/lib/terraforming/template/tf/security_group.erb
@@ -10,16 +10,18 @@ resource "aws_security_group" "<%= module_name_of(security_group) %>" {
         from_port       = <%= permission.from_port || 0 %>
         to_port         = <%= permission.to_port || 0 %>
         protocol        = "<%= permission.ip_protocol %>"
-<%- if permission.ip_ranges.length > 0 -%>
+    <%- if permission.ip_ranges.length > 0 -%>
         cidr_blocks     = <%= permission.ip_ranges.map { |range| range.cidr_ip }.inspect %>
-<%- end -%>
-<%- if permission.user_id_group_pairs.length > 0 -%>
-  <%- self_referenced = self_referenced_permission?(security_group, permission) -%>
-  <%- unless self_referenced -%>
-        security_groups = <%= security_groups.inspect %>
-  <%- end -%>
+    <%- end -%>
+    <%- if security_group.length > 0 -%>
+      <%- if security_groups.length > 0 -%>
+        security_groups = <%= security_groups %>
+      <%- end -%>
+      <%- if permission.user_id_group_pairs.length > 0 -%>
+        <%- self_referenced = self_referenced_permission?(security_group, permission) -%>
         self            = <%= self_referenced %>
-<%- end -%>
+      <%- end -%>
+    <%- end -%>
     }
 
 <% end -%>

--- a/spec/lib/terraforming/resource/security_group_spec.rb
+++ b/spec/lib/terraforming/resource/security_group_spec.rb
@@ -95,6 +95,24 @@ module Terraforming
                 ],
                 ip_ranges: []
               },
+              {
+                ip_protocol: "tcp",
+                from_port: 7777,
+                to_port: 7777,
+                user_id_group_pairs: [
+                  {
+                    user_id: "001122334455",
+                    group_name: "group1",
+                    group_id: "sg-5678efgh"
+                  },
+                  {
+                    user_id: "001122334455",
+                    group_name: "group1",
+                    group_id: "sg-7777abcd"
+                  }
+                ],
+                ip_ranges: []
+              },
             ],
             ip_permissions_egress: [
               {
@@ -184,6 +202,14 @@ resource "aws_security_group" "sg-5678efgh-fuga" {
         to_port         = 22
         protocol        = "tcp"
         cidr_blocks     = ["0.0.0.0/0"]
+        self            = true
+    }
+
+    ingress {
+        from_port       = 7777
+        to_port         = 7777
+        protocol        = "tcp"
+        security_groups = ["sg-7777abcd"]
         self            = true
     }
 
@@ -280,6 +306,14 @@ resource "aws_security_group" "sg-5678efgh-fuga" {
                   "ingress.1909903921.security_groups.#" => "0",
                   "ingress.1909903921.self" => "true",
                   "ingress.1909903921.cidr_blocks.0" => "0.0.0.0/0",
+                  "ingress.#" => "3",
+                  "ingress.1728187046.from_port" => "7777",
+                  "ingress.1728187046.to_port" => "7777",
+                  "ingress.1728187046.protocol" => "tcp",
+                  "ingress.1728187046.cidr_blocks.#" => "0",
+                  "ingress.1728187046.security_groups.#" => "1",
+                  "ingress.1728187046.self" => "true",
+                  "ingress.1728187046.security_groups.1756790741" => "sg-7777abcd"
                 }
               }
             },


### PR DESCRIPTION
security_group fails when multiple user_id_group_pairs and self=1

Hi, I've detected a weird behavior when you have 2 user_id_group_pairs (called security_groups in terraform) and one of those security groups points to self.

This is my case, I create a security group (just to reproduce the issue)

```
resource "aws_security_group" "test-terraform" {
  name = "test-terraform"
  description = "Test the terraform sg"

  ingress {
      from_port = 7777
      to_port = 7777
      self = 1
      protocol = "tcp"
      security_groups = ["sg-12345678"]
  }
```

This produces (as seen on the console)

```
TCP 7777 7777 .... sg-THIS
TCP 7777 7777 .... sg-12345678
```

And, when running a `terraforming sg` it produces

```
    ingress {
        from_port       = 7777
        to_port         = 7777
        protocol        = "tcp"
        self            = true
    }
```

So we are missing the `sg-12345678`

That happens because there is explicity specified to ignore the security groups on this case and just add the `self = 1` here  https://github.com/dtan4/terraforming/blob/master/lib/terraforming/template/tf/security_group.erb#L35-L41

I've added a test for this case.

Can you please take a look and consider merging?

Thanks in advance!
LeoH
