### PR TITLE
Add zsh-completion

### DIFF
--- a/contrib/zsh-completion/_terraforming
+++ b/contrib/zsh-completion/_terraforming
@@ -1,0 +1,65 @@
+#compdef terraforming
+
+function _terraforming() {
+  local context curcontext=$curcontext state line
+  typeset -A opt_args
+  local ret=1
+
+  _arguments -C \
+    '1: :__terraforming_sub_commands' \
+    '*:: :->args' \
+    && ret=0
+
+  case $state in
+    (args)
+      case $words[1] in
+        (help)
+          _arguments -C \
+            '1: :__terraforming_sub_commands' \
+            '(-)*:: :->null_state' \
+            && ret=0
+        ;;
+      (*)
+          _arguments -C \
+            '--merge=[(TFSTATE) tfstate file to merge]:tfstate file to merge:_files' \
+            '--overwrite[Overwrite existing tfstate]' \
+            '--no-overwrite[Do not overwrite existing tfstate]' \
+            '--tfstate[Generate tfstate]' \
+            '--no-tfstate[Do not generate tfstate]' \
+            '--profile[(PROFILE) AWS credentials profile]:AWS credentials profile:__profiles' \
+            && ret=0
+        ;;
+      esac
+      ;;
+  esac
+
+  return ret
+}
+
+__terraforming_sub_commands() {
+  local -a _c
+
+  _c=(
+    "${(@f)$(terraforming --help \
+      | grep '  terraforming' \
+      | sed -E 's/^  terraforming //g' \
+      | sed -E 's/ *(\[COMMAND\])? *# /:/g')}"
+    )
+
+  _describe -t commands terraforming_sub_commands _c
+}
+
+__profiles() {
+  local _profile_path="${HOME}/.aws/credentials"
+  local -a _profiles
+
+  _profiles=(
+    ${(@f)"$(_call_program profiles \
+      "grep -E '^\[.*\]$' "$_profile_path" \
+        | sed -e 's/\[//' -e 's/\]//'")"}
+    )
+
+  _describe -t profiles Profiles _profiles
+}
+
+_terraforming "$@"


### PR DESCRIPTION
I made zsh completion for terraforming. Thanks for your useful tool!

My test environment is:

* OS

```bash
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.11.3
BuildVersion:   15D21
```
* zsh

```bash
$ zsh --version
zsh 5.2 (x86_64-apple-darwin15.0.0)
```

The example outputs of this zsh completion are:

* output1 (show subcommands)

```bash
$ terraforming<tab>
asg    -- AutoScaling Group
dbpg   -- Database Parameter Group
dbsg   -- Database Security Group
dbsn   -- Database Subnet Group
ec2    -- EC2
ecc    -- ElastiCache Cluster
ecsn   -- ElastiCache Subnet Group
eip    -- EIP
elb    -- ELB
help   -- Describe available commands or one specific command
iamg   -- IAM Group
iamgm  -- IAM Group Membership
iamgp  -- IAM Group Policy
iamip  -- IAM Instance Profile
iamp   -- IAM Policy
iamr   -- IAM Role
iamrp  -- IAM Role Policy
iamu   -- IAM User
iamup  -- IAM User Policy
igw    -- Internet Gateway
nacl   -- Network ACL
nif    -- Network Interface
r53r   -- Route53 Record
r53z   -- Route53 Hosted Zone
rds    -- RDS
rs     -- Redshift
rt     -- Route Table
rta    -- Route Table Association
s3     -- S3
sg     -- Security Group
sn     -- Subnet
vpc    -- VPC
```

* output2 (show options)

```bash
$ terraforming vpc -<tab>
--merge         -- (TFSTATE) tfstate file to merge
--no-overwrite  -- Do not overwrite existing tfstate
--no-tfstate    -- Do not generate tfstate
--overwrite     -- Overwrite existing tfstate
--profile       -- (PROFILE) AWS credentials profile
--tfstate       -- Generate tfstate
```

* output3 (show profiles)

```bash
$ terraforming vpc --profile <tab>
default  test
```