### PR TITLE
Add elasticache redis port

### DIFF
--- a/lib/terraforming/resource/elasti_cache_cluster.rb
+++ b/lib/terraforming/resource/elasti_cache_cluster.rb
@@ -36,8 +36,11 @@ module Terraforming
             "tags.#" => "0",
           }
 
-          attributes["port"] =
-            cache_cluster.configuration_endpoint.port.to_s if cache_cluster.configuration_endpoint
+          attributes["port"] = if cache_cluster.configuration_endpoint
+            cache_cluster.configuration_endpoint.port.to_s
+          else
+            cache_cluster.cache_nodes[0].endpoint.port.to_s
+          end
 
           resources["aws_elasticache_cluster.#{cache_cluster.cache_cluster_id}"] = {
             "type" => "aws_elasticache_cluster",

--- a/lib/terraforming/template/tf/elasti_cache_cluster.erb
+++ b/lib/terraforming/template/tf/elasti_cache_cluster.erb
@@ -8,6 +8,8 @@ resource "aws_elasticache_cluster" "<%= cache_cluster.cache_cluster_id %>" {
     parameter_group_name = "<%= cache_cluster.cache_parameter_group.cache_parameter_group_name %>"
   <%- if cache_cluster.configuration_endpoint -%>
     port                 = <%= cache_cluster.configuration_endpoint.port %>
+  <%- else -%>
+    port                 = <%= cache_cluster.cache_nodes[0].endpoint.port %>
   <%- end -%>
   <%- if cluster_in_vpc?(cache_cluster) -%>
     subnet_group_name    = "<%= cache_cluster.cache_subnet_group_name %>"

--- a/spec/lib/terraforming/resource/elasti_cache_cluster_spec.rb
+++ b/spec/lib/terraforming/resource/elasti_cache_cluster_spec.rb
@@ -78,7 +78,7 @@ module Terraforming
                 cache_node_create_time: Time.parse("2014-08-28 12:51:55 UTC"),
                 endpoint: {
                   address: "fuga.def456.0001.apne1.cache.amazonaws.com",
-                  port: 11211
+                  port: 6379
                 },
                 parameter_group_status: "in-sync",
                 customer_availability_zone: "ap-northeast-1b"
@@ -116,6 +116,7 @@ resource "aws_elasticache_cluster" "fuga" {
     node_type            = "cache.t2.micro"
     num_cache_nodes      = 1
     parameter_group_name = "default.redis2.8"
+    port                 = 6379
     security_group_names = ["sg-hoge"]
 }
 
@@ -139,11 +140,11 @@ resource "aws_elasticache_cluster" "fuga" {
                   "node_type" => "cache.m1.small",
                   "num_cache_nodes" => "1",
                   "parameter_group_name" => "default.memcached1.4",
-                  "port" => "11211",
                   "security_group_ids.#" => "1",
                   "security_group_names.#" => "0",
                   "subnet_group_name" => "subnet-hoge",
                   "tags.#" => "0",
+                  "port" => "11211"
                 }
               }
             },
@@ -164,6 +165,7 @@ resource "aws_elasticache_cluster" "fuga" {
                   "security_group_names.#" => "1",
                   "subnet_group_name" => "subnet-fuga",
                   "tags.#" => "0",
+                  "port" => "6379"
                 }
               }
             }


### PR DESCRIPTION
A redis elasticache cluster can only have one node (according to the terraform documentation), so we can use the cache_nodes[0].endpoint.port to populate the port value.