### PR TITLE
[route53 records] Default weight should be "-1"

### DIFF
--- a/lib/terraforming/resource/route53_record.rb
+++ b/lib/terraforming/resource/route53_record.rb
@@ -34,7 +34,7 @@ module Terraforming
           attributes["alias.#"] = "1" if record.alias_target
           attributes["records.#"] = record.resource_records.length.to_s unless record.resource_records.empty?
           attributes["ttl"] = record.ttl.to_s if record.ttl
-          attributes["weight"] = record.weight.to_s if record.weight
+          attributes["weight"] = record.weight ? record.weight.to_s : "-1"
           attributes["set_identifier"] = record.set_identifier if record.set_identifier
 
           resources["aws_route53_record.#{module_name_of(record)}"] = {

--- a/spec/lib/terraforming/resource/route53_record_spec.rb
+++ b/spec/lib/terraforming/resource/route53_record_spec.rb
@@ -39,7 +39,7 @@ module Terraforming
             name: "hoge.net.",
             type: "A",
             ttl: 3600,
-            weight: nil,
+            weight: "-1",
             set_identifier: "dev",
             resource_records: [
               { value: "123.456.78.90" },
@@ -72,7 +72,7 @@ module Terraforming
             name: '\052.example.net.',
             type: "CNAME",
             ttl: 3600,
-            weight: nil,
+            weight: "-1",
             set_identifier: nil,
             resource_records: [
               { value: "example.com" }

--- a/spec/lib/terraforming/resource/route53_record_spec.rb
+++ b/spec/lib/terraforming/resource/route53_record_spec.rb
@@ -39,7 +39,7 @@ module Terraforming
             name: "hoge.net.",
             type: "A",
             ttl: 3600,
-            weight: "-1",
+            weight: nil,
             set_identifier: "dev",
             resource_records: [
               { value: "123.456.78.90" },
@@ -72,7 +72,7 @@ module Terraforming
             name: '\052.example.net.',
             type: "CNAME",
             ttl: 3600,
-            weight: "-1",
+            weight: nil,
             set_identifier: nil,
             resource_records: [
               { value: "example.com" }
@@ -145,6 +145,7 @@ resource "aws_route53_record" "-052-example-net-CNAME" {
                   "records.#" => "2",
                   "ttl" => "3600",
                   "set_identifier" => "dev",
+                  "weight" => "-1",
                 },
               }
             },
@@ -173,6 +174,7 @@ resource "aws_route53_record" "-052-example-net-CNAME" {
                   "zone_id" => "CDEFGHIJKLMNOP",
                   "records.#" => "1",
                   "ttl" => "3600",
+                  "weight" => "-1",
                 },
               }
             },


### PR DESCRIPTION
Otherwise terraform wants to change all weight "" => "-1" which is a noop, it just changes the terraform.tfstate actually.

The official documentation says

https://www.terraform.io/docs/providers/aws/r/route53_record.html

```
Note: The weight attribute uses a special sentinel value of -1 for a default in
Terraform. This allows Terraform to distinquish between a 0 value and an empty
value in the configuration (none specified). As a result, a weight of -1 will
be present in the statefile if weight is omitted in the configuration.
```