### PR TITLE
Fix travis guard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
 - 2.3.0
 - 2.2.4
 - 2.1.8
-- 2.0
 env:
 - secure: n0mxwnyjuXI4mJO4mp++2TnsPJ+XgCF/J1U2L5piE5j3xMhSU+5V0JrA1uFlS0Pemb44M7BjgmF9S4G35BwyAQpctpCYhqy9tFa6+Y6nxEv5hCv2cZz7BSAZM6eb+zq20409hxTHRaQOr1DBeE4R5S2PrmOXRqvYfTRv3LNSLFk=
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-- 2.3.0
-- 2.2.4
-- 2.1.8
+- 2.3.1
+- 2.2.5
+- 2.1.10
 env:
 - secure: n0mxwnyjuXI4mJO4mp++2TnsPJ+XgCF/J1U2L5piE5j3xMhSU+5V0JrA1uFlS0Pemb44M7BjgmF9S4G35BwyAQpctpCYhqy9tFa6+Y6nxEv5hCv2cZz7BSAZM6eb+zq20409hxTHRaQOr1DBeE4R5S2PrmOXRqvYfTRv3LNSLFk=
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,16 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in terraforming.gemspec
 gemspec
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.0")
+    gem "listen", "~> 3.1.0"
+  else
+    gem "listen", "< 3.1.0"
+  end
+
+  gem "terminal-notifier-guard"
+end

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Export existing AWS resources to [Terraform](https://terraform.io/) style (tf, t
 
 ## Supported version
 
-Ruby 2.x
+Ruby 2.1 or higher
 
 ## Installation
 

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-rspec"
+  spec.add_development_dependency "listen", "~> 3.0.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "simplecov", "~> 0.11.1"

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -26,11 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "codeclimate-test-reporter"
-  spec.add_development_dependency "guard"
-  spec.add_development_dependency "guard-rspec"
-  spec.add_development_dependency "listen", "~> 3.0.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "simplecov", "~> 0.11.1"
-  spec.add_development_dependency "terminal-notifier-guard"
 end


### PR DESCRIPTION
## WHY
Recently Travis CI fails (https://travis-ci.org/dtan4/terraforming/builds/126665204) because the latest Guard [droped Ruby 2.1 & 2.0 support](https://github.com/guard/guard/tree/cf51959d9c9bdcb6cab0b66aeb9735d76d4f2457).

## WHAT
Remove guard dependencies from gemspec. Guard family is not necessary for some developers.
And also, drop Ruby 2.0 support from the next version. Ruby 2.0 is [no longer supported officially (EOL)](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/).