### PR TITLE
[sg] Simplify generated security-group names

### DIFF
--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -74,7 +74,11 @@ module Terraforming
       end
 
       def module_name_of(security_group)
-        normalize_module_name("#{security_group.group_id}-#{security_group.group_name}")
+        if security_group.vpc_id.nil?
+          normalize_module_name("#{security_group.group_name}")
+        else
+          normalize_module_name("#{security_group.vpc_id}-#{security_group.group_name}")
+        end
       end
 
       def permission_attributes_of(security_group, permission, type)

--- a/spec/lib/terraforming/resource/security_group_spec.rb
+++ b/spec/lib/terraforming/resource/security_group_spec.rb
@@ -118,7 +118,7 @@ module Terraforming
       describe ".tf" do
         it "should generate tf" do
           expect(described_class.tf(client: client)).to eq <<-EOS
-resource "aws_security_group" "sg-1234abcd-hoge" {
+resource "aws_security_group" "hoge" {
     name        = "hoge"
     description = "Group for hoge"
     vpc_id      = ""
@@ -141,7 +141,7 @@ resource "aws_security_group" "sg-1234abcd-hoge" {
 
 }
 
-resource "aws_security_group" "sg-5678efgh-fuga" {
+resource "aws_security_group" "vpc-1234abcd-fuga" {
     name        = "fuga"
     description = "Group for fuga"
     vpc_id      = "vpc-1234abcd"
@@ -185,7 +185,7 @@ resource "aws_security_group" "sg-5678efgh-fuga" {
       describe ".tfstate" do
         it "should generate tfstate" do
           expect(described_class.tfstate(client: client)).to eq({
-            "aws_security_group.sg-1234abcd-hoge" => {
+            "aws_security_group.hoge" => {
               "type" => "aws_security_group",
               "primary" => {
                 "id" => "sg-1234abcd",
@@ -215,7 +215,7 @@ resource "aws_security_group" "sg-5678efgh-fuga" {
                 }
               }
             },
-            "aws_security_group.sg-5678efgh-fuga" => {
+            "aws_security_group.vpc-1234abcd-fuga" => {
               "type" => "aws_security_group",
               "primary" => {
                 "id" => "sg-5678efgh",


### PR DESCRIPTION
As described in #205, the purpose of this patch is to provide a better out of
the box security group naming convention. The current approach
`[security-group-id]-[security-group-name]` is not very convenient, since we
don't know the security group id in advance. The only reason it's useful is
that it provides 100% unique security group resoruce ids.

A better approach is to use security group names for EC2 Classic, and vpc_id as
prefix for VPC security groups.

This also keeps the unique resource ids but makes them easier to handle
and read.