### PR TITLE
[IAM]: Prefix inline policy terraform name to prevent `resource repeated multiple times` errors

### DIFF
--- a/lib/terraforming/resource/iam_group_policy.rb
+++ b/lib/terraforming/resource/iam_group_policy.rb
@@ -27,7 +27,7 @@ module Terraforming
             "name" => policy.policy_name,
             "policy" => prettify_policy(policy.policy_document, breakline: true, unescape: true)
           }
-          resources["aws_iam_group_policy.#{policy.policy_name}"] = {
+          resources["aws_iam_group_policy.#{unique_name(policy)}"] = {
             "type" => "aws_iam_group_policy",
             "primary" => {
               "id" => iam_group_policy_id_of(policy),
@@ -40,6 +40,10 @@ module Terraforming
       end
 
       private
+
+      def unique_name(policy)
+        "#{policy.group_name}_#{policy.policy_name}"
+      end
 
       def iam_groups
         @client.list_groups.groups

--- a/lib/terraforming/resource/iam_role_policy.rb
+++ b/lib/terraforming/resource/iam_role_policy.rb
@@ -27,7 +27,7 @@ module Terraforming
             "policy" => prettify_policy(policy.policy_document, breakline: true, unescape: true),
             "role" => policy.role_name,
           }
-          resources["aws_iam_role_policy.#{policy.policy_name}"] = {
+          resources["aws_iam_role_policy.#{unique_name(policy)}"] = {
             "type" => "aws_iam_role_policy",
             "primary" => {
               "id" => iam_role_policy_id_of(policy),
@@ -40,6 +40,10 @@ module Terraforming
       end
 
       private
+
+      def unique_name(policy)
+        "#{policy.role_name}_#{policy.policy_name}"
+      end
 
       def iam_roles
         @client.list_roles.roles

--- a/lib/terraforming/resource/iam_user_policy.rb
+++ b/lib/terraforming/resource/iam_user_policy.rb
@@ -27,7 +27,7 @@ module Terraforming
             "policy" => prettify_policy(policy.policy_document, breakline: true, unescape: true),
             "user" => policy.user_name,
           }
-          resources["aws_iam_user_policy.#{policy.policy_name}"] = {
+          resources["aws_iam_user_policy.#{unique_name(policy)}"] = {
             "type" => "aws_iam_user_policy",
             "primary" => {
               "id" => iam_user_policy_id_of(policy),
@@ -40,6 +40,10 @@ module Terraforming
       end
 
       private
+
+      def unique_name(policy)
+        "#{policy.user_name}_#{policy.policy_name}"
+      end
 
       def iam_users
         @client.list_users.users

--- a/lib/terraforming/template/tf/iam_group_policy.erb
+++ b/lib/terraforming/template/tf/iam_group_policy.erb
@@ -1,5 +1,5 @@
 <% iam_group_policies.each do |policy| -%>
-resource "aws_iam_group_policy" "<%= policy.policy_name %>" {
+resource "aws_iam_group_policy" "<%= unique_name(policy) %>" {
     name   = "<%= policy.policy_name %>"
     group  = "<%= policy.group_name %>"
     policy = <<POLICY

--- a/lib/terraforming/template/tf/iam_role_policy.erb
+++ b/lib/terraforming/template/tf/iam_role_policy.erb
@@ -1,5 +1,5 @@
 <% iam_role_policies.each do |policy| -%>
-resource "aws_iam_role_policy" "<%= policy.policy_name %>" {
+resource "aws_iam_role_policy" "<%= unique_name(policy) %>" {
     name   = "<%= policy.policy_name %>"
     role   = "<%= policy.role_name %>"
     policy = <<POLICY

--- a/lib/terraforming/template/tf/iam_user_policy.erb
+++ b/lib/terraforming/template/tf/iam_user_policy.erb
@@ -1,5 +1,5 @@
 <% iam_user_policies.each do |policy| -%>
-resource "aws_iam_user_policy" "<%= policy.policy_name %>" {
+resource "aws_iam_user_policy" "<%= unique_name(policy) %>" {
     name   = "<%= policy.policy_name %>"
     user   = "<%= policy.user_name %>"
     policy = <<POLICY

--- a/spec/lib/terraforming/resource/iam_group_policy_spec.rb
+++ b/spec/lib/terraforming/resource/iam_group_policy_spec.rb
@@ -51,7 +51,7 @@ module Terraforming
       describe ".tf" do
         it "should generate tf" do
           expect(described_class.tf(client: client)).to eq <<-EOS
-resource "aws_iam_group_policy" "hoge_policy" {
+resource "aws_iam_group_policy" "hoge_hoge_policy" {
     name   = "hoge_policy"
     group  = "hoge"
     policy = <<POLICY
@@ -70,7 +70,7 @@ resource "aws_iam_group_policy" "hoge_policy" {
 POLICY
 }
 
-resource "aws_iam_group_policy" "fuga_policy" {
+resource "aws_iam_group_policy" "fuga_fuga_policy" {
     name   = "fuga_policy"
     group  = "fuga"
     policy = <<POLICY
@@ -96,7 +96,7 @@ POLICY
       describe ".tfstate" do
         it "should generate tfstate" do
           expect(described_class.tfstate(client: client)).to eq({
-            "aws_iam_group_policy.hoge_policy" => {
+            "aws_iam_group_policy.hoge_hoge_policy" => {
               "type" => "aws_iam_group_policy",
               "primary" => {
                 "id" => "hoge:hoge_policy",
@@ -108,7 +108,7 @@ POLICY
                 }
               }
             },
-            "aws_iam_group_policy.fuga_policy" => {
+            "aws_iam_group_policy.fuga_fuga_policy" => {
               "type" => "aws_iam_group_policy",
               "primary" => {
                 "id" => "fuga:fuga_policy",

--- a/spec/lib/terraforming/resource/iam_role_policy_spec.rb
+++ b/spec/lib/terraforming/resource/iam_role_policy_spec.rb
@@ -53,7 +53,7 @@ module Terraforming
       describe ".tf" do
         it "should generate tf" do
           expect(described_class.tf(client: client)).to eq <<-EOS
-resource "aws_iam_role_policy" "hoge_role_policy" {
+resource "aws_iam_role_policy" "hoge_role_hoge_role_policy" {
     name   = "hoge_role_policy"
     role   = "hoge_role"
     policy = <<POLICY
@@ -76,7 +76,7 @@ resource "aws_iam_role_policy" "hoge_role_policy" {
 POLICY
 }
 
-resource "aws_iam_role_policy" "fuga_role_policy" {
+resource "aws_iam_role_policy" "fuga_role_fuga_role_policy" {
     name   = "fuga_role_policy"
     role   = "fuga_role"
     policy = <<POLICY
@@ -101,7 +101,7 @@ POLICY
       describe ".tfstate" do
         it "should generate tfstate" do
           expect(described_class.tfstate(client: client)).to eq({
-            "aws_iam_role_policy.hoge_role_policy" => {
+            "aws_iam_role_policy.hoge_role_hoge_role_policy" => {
               "type" => "aws_iam_role_policy",
               "primary" => {
                 "id" => "hoge_role:hoge_role_policy",
@@ -113,7 +113,7 @@ POLICY
                 }
               }
             },
-            "aws_iam_role_policy.fuga_role_policy" => {
+            "aws_iam_role_policy.fuga_role_fuga_role_policy" => {
               "type" => "aws_iam_role_policy",
               "primary" => {
                 "id" => "fuga_role:fuga_role_policy",

--- a/spec/lib/terraforming/resource/iam_user_policy_spec.rb
+++ b/spec/lib/terraforming/resource/iam_user_policy_spec.rb
@@ -53,7 +53,7 @@ module Terraforming
       describe ".tf" do
         it "should generate tf" do
           expect(described_class.tf(client: client)).to eq <<-EOS
-resource "aws_iam_user_policy" "hoge_policy" {
+resource "aws_iam_user_policy" "hoge_hoge_policy" {
     name   = "hoge_policy"
     user   = "hoge"
     policy = <<POLICY
@@ -72,7 +72,7 @@ resource "aws_iam_user_policy" "hoge_policy" {
 POLICY
 }
 
-resource "aws_iam_user_policy" "fuga_policy" {
+resource "aws_iam_user_policy" "fuga_fuga_policy" {
     name   = "fuga_policy"
     user   = "fuga"
     policy = <<POLICY
@@ -98,7 +98,7 @@ POLICY
       describe ".tfstate" do
         it "should generate tfstate" do
           expect(described_class.tfstate(client: client)).to eq({
-            "aws_iam_user_policy.hoge_policy" => {
+            "aws_iam_user_policy.hoge_hoge_policy" => {
               "type" => "aws_iam_user_policy",
               "primary" => {
                 "id" => "hoge:hoge_policy",
@@ -110,7 +110,7 @@ POLICY
                 }
               }
             },
-            "aws_iam_user_policy.fuga_policy" => {
+            "aws_iam_user_policy.fuga_fuga_policy" => {
               "type" => "aws_iam_user_policy",
               "primary" => {
                 "id" => "fuga:fuga_policy",


### PR DESCRIPTION
AWS allows different inline policies to have the same name as long as they belong to different resources (e.g. different user, role, or group) - so the terraform resource name ought to be more unique than just copying the inline policy name.

This change sets the terraform resource name as the combination of the resource and policy names, which is more verbose but prevents duplicate resource errors.