### PR TITLE
Kbroughton/extended-tag-filtering

### DIFF
--- a/lib/terraforming/resource/auto_scaling_group.rb
+++ b/lib/terraforming/resource/auto_scaling_group.rb
@@ -49,6 +49,8 @@ module Terraforming
             })
           end
 
+
+          attributes.merge!(tags_attributes_of(group))
           resources["aws_autoscaling_group.#{module_name_of(group)}"] = {
             "type" => "aws_autoscaling_group",
             "primary" => {
@@ -65,6 +67,13 @@ module Terraforming
       end
 
       private
+
+      def tags_attributes_of(group)
+        tags = group.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
 
       def auto_scaling_groups
         @client.describe_auto_scaling_groups.map(&:auto_scaling_groups).flatten

--- a/lib/terraforming/resource/ec2.rb
+++ b/lib/terraforming/resource/ec2.rb
@@ -50,6 +50,8 @@ module Terraforming
 
           attributes["subnet_id"] = instance.subnet_id if in_vpc?(instance)
 
+
+          attributes.merge!(tags_attributes_of(instance))
           resources["aws_instance.#{module_name_of(instance)}"] = {
             "type" => "aws_instance",
             "primary" => {
@@ -66,6 +68,13 @@ module Terraforming
       end
 
       private
+
+      def tags_attributes_of(instance)
+        tags = instance.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
 
       def block_device_ids_of(instance)
         instance.block_device_mappings.map { |bdm| bdm.ebs.volume_id }

--- a/lib/terraforming/resource/elb.rb
+++ b/lib/terraforming/resource/elb.rb
@@ -43,6 +43,8 @@ module Terraforming
           attributes.merge!(tags_attributes_of(load_balancer))
 
 
+
+          attributes.merge!(tags_attributes_of(load_balancer))
           resources["aws_elb.#{module_name_of(load_balancer)}"] = {
             "type" => "aws_elb",
             "primary" => {
@@ -175,3 +177,10 @@ module Terraforming
     end
   end
 end
+
+      def tags_attributes_of(load_balancer)
+        tags = load_balancer.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end

--- a/lib/terraforming/resource/internet_gateway.rb
+++ b/lib/terraforming/resource/internet_gateway.rb
@@ -28,6 +28,8 @@ module Terraforming
             "vpc_id" => internet_gateway.attachments[0].vpc_id,
             "tags.#" => internet_gateway.tags.length.to_s,
           }
+
+          attributes.merge!(tags_attributes_of(internet_gateway))
           resources["aws_internet_gateway.#{module_name_of(internet_gateway)}"] = {
             "type" => "aws_internet_gateway",
             "primary" => {
@@ -41,6 +43,13 @@ module Terraforming
       end
 
       private
+
+      def tags_attributes_of(internet_gateway)
+        tags = internet_gateway.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
 
       def internet_gateways
         @client.describe_internet_gateways.internet_gateways

--- a/lib/terraforming/resource/network_acl.rb
+++ b/lib/terraforming/resource/network_acl.rb
@@ -29,6 +29,8 @@ module Terraforming
             "tags.#" => network_acl.tags.length.to_s,
             "vpc_id" => network_acl.vpc_id,
           }
+
+          attributes.merge!(tags_attributes_of(network_acl))
           resources["aws_network_acl.#{module_name_of(network_acl)}"] = {
             "type" => "aws_network_acl",
             "primary" => {
@@ -42,6 +44,13 @@ module Terraforming
       end
 
       private
+
+      def tags_attributes_of(network_acl)
+        tags = network_acl.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
 
       def default_entry?(entry)
         entry.rule_number == default_rule_number

--- a/lib/terraforming/resource/network_interface.rb
+++ b/lib/terraforming/resource/network_interface.rb
@@ -30,6 +30,8 @@ module Terraforming
             "subnet_id" => network_interface.subnet_id,
             "tags.#" => network_interface.tag_set.length.to_s,
           }
+
+          attributes.merge!(tags_attributes_of(network_interface))
           resources["aws_network_interface.#{module_name_of(network_interface)}"] = {
             "type" => "aws_network_interface",
             "primary" => {
@@ -50,6 +52,13 @@ module Terraforming
 
       def private_ips_of(network_interface)
         network_interface.private_ip_addresses.map{|addr| addr.private_ip_address }
+
+      def tags_attributes_of(network_interface)
+        tags = network_interface.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
       end
 
       def security_groups_of(network_interface)

--- a/lib/terraforming/resource/route53_zone.rb
+++ b/lib/terraforming/resource/route53_zone.rb
@@ -34,6 +34,8 @@ module Terraforming
             "vpc_region" => vpc ? vpc.vpc_region : "",
             "zone_id" => zone_id,
           }
+
+          attributes.merge!(tags_attributes_of(hosted_zone))
           resources["aws_route53_zone.#{module_name_of(hosted_zone)}"] = {
             "type" => "aws_route53_zone",
             "primary" => {
@@ -75,6 +77,13 @@ module Terraforming
 
       def private_hosted_zone?(hosted_zone)
         hosted_zone.hosted_zone.config.private_zone
+
+      def tags_attributes_of(hosted_zone)
+        tags = hosted_zone.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
       end
 
       def vpc_of(hosted_zone)

--- a/lib/terraforming/resource/route_table.rb
+++ b/lib/terraforming/resource/route_table.rb
@@ -30,6 +30,8 @@ module Terraforming
           attributes.merge!(routes_attributes_of(route_table))
           attributes.merge!(propagating_vgws_attributes_of(route_table))
 
+
+          attributes.merge!(tags_attributes_of(route_table))
           resources["aws_route_table.#{module_name_of(route_table)}"] = {
             "type" => "aws_route_table",
             "primary" => {
@@ -43,6 +45,13 @@ module Terraforming
       end
 
       private
+
+      def tags_attributes_of(route_table)
+        tags = route_table.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
 
       def routes_of(route_table)
         route_table.routes.reject do |route|

--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -33,6 +33,8 @@ module Terraforming
           attributes.merge!(egress_attributes_of(security_group))
           attributes.merge!(ingress_attributes_of(security_group))
 
+
+          attributes.merge!(tags_attributes_of(security_group))
           resources["aws_security_group.#{module_name_of(security_group)}"] = {
             "type" => "aws_security_group",
             "primary" => {
@@ -46,6 +48,13 @@ module Terraforming
       end
 
       private
+
+      def tags_attributes_of(security_group)
+        tags = security_group.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
 
       def ingress_attributes_of(security_group)
         ingresses = dedup_permissions(security_group.ip_permissions, security_group.group_id)

--- a/lib/terraforming/resource/subnet.rb
+++ b/lib/terraforming/resource/subnet.rb
@@ -29,6 +29,8 @@ module Terraforming
             "tags.#" => subnet.tags.length.to_s,
             "vpc_id" => subnet.vpc_id,
           }
+
+          attributes.merge!(tags_attributes_of(subnet))
           resources["aws_subnet.#{module_name_of(subnet)}"] = {
             "type" => "aws_subnet",
             "primary" => {
@@ -42,6 +44,13 @@ module Terraforming
       end
 
       private
+
+      def tags_attributes_of(subnet)
+        tags = subnet.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
 
       def subnets
         @client.describe_subnets.subnets

--- a/lib/terraforming/resource/vpc.rb
+++ b/lib/terraforming/resource/vpc.rb
@@ -29,6 +29,8 @@ module Terraforming
             "instance_tenancy" => vpc.instance_tenancy,
             "tags.#" => vpc.tags.length.to_s,
           }
+
+          attributes.merge!(tags_attributes_of(vpc))
           resources["aws_vpc.#{module_name_of(vpc)}"] = {
             "type" => "aws_vpc",
             "primary" => {
@@ -42,6 +44,13 @@ module Terraforming
       end
 
       private
+
+      def tags_attributes_of(vpc)
+        tags = vpc.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
 
       def enable_dns_hostnames?(vpc)
         vpc_attribute(vpc, :enableDnsHostnames).enable_dns_hostnames.value

--- a/lib/terraforming/resource/vpn_gateway.rb
+++ b/lib/terraforming/resource/vpn_gateway.rb
@@ -29,6 +29,8 @@ module Terraforming
             "availability_zone" => vpn_gateway.availability_zone,
             "tags.#" => vpn_gateway.tags.length.to_s,
           }
+
+          attributes.merge!(tags_attributes_of(vpn_gateway))
           resources["aws_vpn_gateway.#{module_name_of(vpn_gateway)}"] = {
             "type" => "aws_vpn_gateway",
             "primary" => {
@@ -42,6 +44,13 @@ module Terraforming
       end
 
       private
+
+      def tags_attributes_of(vpn_gateway)
+        tags = vpn_gateway.tags
+        attributes = { "tags.#" => tags.length.to_s }
+        tags.each { |tag| attributes["tags.#{tag.key}"] = tag.value }
+        attributes
+      end
 
       def vpn_gateways
         @client.describe_vpn_gateways.vpn_gateways

--- a/lib/terraforming/version.rb
+++ b/lib/terraforming/version.rb
@@ -1,3 +1,3 @@
 module Terraforming
-  VERSION = "0.7.0"
+  VERSION = "0.7.2"
 end


### PR DESCRIPTION
Based on https://github.com/dtan4/terraforming/compare/master...soapy1:pre-filtering-resources
I extended it from filtering for ec2 to 10 others. It could probably be extended to all.

This PR also adds support for tags.  Right now most modules return tags.# = number of tags.  But you don't get the actual tags.  Copying the route_table.rb I templated it to the 10 others that support filtering.

I've included the ansible script I used to automate modifications.  The fix_tags.yml and hosts would be deleted from a mature PR but might be useful to someone wanting to finish this work.