### PR TITLE
Add access_logs attribute to ELB

### DIFF
--- a/lib/terraforming/resource/elb.rb
+++ b/lib/terraforming/resource/elb.rb
@@ -36,6 +36,11 @@ module Terraforming
             "source_security_group" => load_balancer.source_security_group.group_name,
           }
 
+          if load_balancer_attributes.access_log.enabled
+
+          end
+
+          attributes.merge!(access_logs_attributes_of(load_balancer_attributes))
           attributes.merge!(healthcheck_attributes_of(load_balancer))
           attributes.merge!(listeners_attributes_of(load_balancer))
           attributes.merge!(sg_attributes_of(load_balancer))
@@ -53,6 +58,23 @@ module Terraforming
           }
 
           resources
+        end
+      end
+
+      def access_logs_attributes_of(load_balancer_attributes)
+        access_log = load_balancer_attributes.access_log
+
+        if access_log.enabled
+          {
+            "access_logs.#" => "1",
+            "access_logs.0.bucket" => access_log.s3_bucket_name,
+            "access_logs.0.bucket_prefix" => access_log.s3_bucket_prefix,
+            "access_logs.0.interval" => access_log.emit_interval.to_s,
+          }
+        else
+          {
+            "access_logs.#" => "0",
+          }
         end
       end
 

--- a/lib/terraforming/template/tf/elb.erb
+++ b/lib/terraforming/template/tf/elb.erb
@@ -15,6 +15,14 @@ resource "aws_elb" "<%= module_name_of(load_balancer) %>" {
     connection_draining_timeout = <%= load_balancer_attributes.connection_draining.timeout %>
     internal                    = <%= internal?(load_balancer).to_s %>
 
+<%- if load_balancer_attributes.access_log.enabled -%>
+    access_logs {
+        bucket        = "<%= load_balancer_attributes.access_log.s3_bucket_name %>"
+        bucket_prefix = "<%= load_balancer_attributes.access_log.s3_bucket_prefix %>"
+        interval      = <%= load_balancer_attributes.access_log.emit_interval %>
+    }
+
+<%- end -%>
 <% load_balancer.listener_descriptions.map { |ld| ld.listener }.map do |listener| -%>
     listener {
         instance_port      = <%= listener.instance_port %>

--- a/spec/lib/terraforming/resource/elb_spec.rb
+++ b/spec/lib/terraforming/resource/elb_spec.rb
@@ -145,7 +145,12 @@ module Terraforming
       let(:fuga_attributes) do
         {
           cross_zone_load_balancing: { enabled: true },
-          access_log: { enabled: false },
+          access_log: {
+            enabled: true,
+            s3_bucket_name: "hoge-elb-logs",
+            emit_interval: 60,
+            s3_bucket_prefix: "fuga",
+          },
           connection_draining: { enabled: true, timeout: 900 },
           connection_settings: { idle_timeout: 90 },
           additional_attributes: []
@@ -215,6 +220,12 @@ resource "aws_elb" "fuga" {
     connection_draining_timeout = 900
     internal                    = true
 
+    access_logs {
+        bucket        = "hoge-elb-logs"
+        bucket_prefix = "fuga"
+        interval      = 60
+    }
+
     listener {
         instance_port      = 80
         instance_protocol  = "http"
@@ -248,6 +259,7 @@ resource "aws_elb" "fuga" {
               "primary" => {
                 "id" => "hoge",
                 "attributes" => {
+                  "access_logs.#" => "0",
                   "availability_zones.#" => "2",
                   "connection_draining" => "true",
                   "connection_draining_timeout" => "300",
@@ -287,6 +299,10 @@ resource "aws_elb" "fuga" {
               "primary" => {
                 "id" => "fuga",
                 "attributes" => {
+                  "access_logs.#" => "1",
+                  "access_logs.0.bucket" => "hoge-elb-logs",
+                  "access_logs.0.bucket_prefix" => "fuga",
+                  "access_logs.0.interval" => "60",
                   "availability_zones.#" => "2",
                   "connection_draining" => "true",
                   "connection_draining_timeout" => "900",


### PR DESCRIPTION
ELB `access_logs` was introduces at [Terraform v0.6.7](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#067-november-23-2015).

## REF
- [AWS: aws_elb - Terraform by HashiCorp](https://www.terraform.io/docs/providers/aws/r/elb.html)