### PR TITLE
Fix ox load error

### DIFF
--- a/lib/terraforming.rb
+++ b/lib/terraforming.rb
@@ -1,5 +1,12 @@
 require "oj"
-require "ox"
+
+begin
+  require "ox"
+rescue NameError => e
+  spec = Gem::Specification.stubs.find {|s| s.name == 'ox' }
+  raise e unless spec
+  require File.join(spec.gem_dir, "lib/ox")
+end
 
 require "aws-sdk-core"
 require "erb"


### PR DESCRIPTION
see https://github.com/dtan4/terraforming/issues/153

NameError will occur under the following conditions.
* OS X
* ruby 2.2.4p230 (rbenv)
* ox 2.4.1 ( **MUST** Only 2.4.1 is installed.)

## Cause
ox 2.4.1 install .bundle file to `/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/extensions/x86_64-darwin-15/2.2.0/ox-2.4.1/ox.bundle`.
When `require "ox"` executed, will try to load  above file.
But correct file is `.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/ox-2.4.1/lib/ox.rb`

This problem does not occur in the environment in which is installed multiple version ox.

Please merge if there is no problem.

Thanks.

