### PR TITLE
add pagination to all resources

### DIFF
--- a/lib/terraforming/resource/db_parameter_group.rb
+++ b/lib/terraforming/resource/db_parameter_group.rb
@@ -43,11 +43,11 @@ module Terraforming
       private
 
       def db_parameter_groups
-        @client.describe_db_parameter_groups.db_parameter_groups
+        @client.describe_db_parameter_groups.map(&:db_parameter_groups).flatten
       end
 
       def db_parameters_in(parameter_group)
-        @client.describe_db_parameters(db_parameter_group_name: parameter_group.db_parameter_group_name).parameters
+        @client.describe_db_parameters(db_parameter_group_name: parameter_group.db_parameter_group_name).map(&:parameters).flatten
       end
 
       def module_name_of(parameter_group)

--- a/lib/terraforming/resource/db_security_group.rb
+++ b/lib/terraforming/resource/db_security_group.rb
@@ -46,7 +46,7 @@ module Terraforming
       end
 
       def db_security_groups
-        @client.describe_db_security_groups.db_security_groups.select { |sg| ingresses_of(sg).length > 0 }
+        @client.describe_db_security_groups.map(&:db_security_groups).flatten.select { |sg| ingresses_of(sg).length > 0 }
       end
 
       def module_name_of(security_group)

--- a/lib/terraforming/resource/db_subnet_group.rb
+++ b/lib/terraforming/resource/db_subnet_group.rb
@@ -41,7 +41,7 @@ module Terraforming
       private
 
       def db_subnet_groups
-        @client.describe_db_subnet_groups.db_subnet_groups
+        @client.describe_db_subnet_groups.map(&:db_subnet_groups).flatten
       end
 
       def module_name_of(subnet_group)

--- a/lib/terraforming/resource/ec2.rb
+++ b/lib/terraforming/resource/ec2.rb
@@ -73,7 +73,7 @@ module Terraforming
 
       def block_devices_of(instance)
         return [] unless instance.block_device_mappings.length > 0
-        @client.describe_volumes(volume_ids: block_device_ids_of(instance)).volumes
+        @client.describe_volumes(volume_ids: block_device_ids_of(instance)).map(&:volumes).flatten
       end
 
       def block_device_mapping_of(instance, volume_id)
@@ -101,7 +101,7 @@ module Terraforming
       end
 
       def instances
-        @client.describe_instances.reservations.map(&:instances).flatten.reject { |instance| instance.state.name == "terminated" }
+        @client.describe_instances.map(&:reservations).flatten.map(&:instances).flatten.reject { |instance| instance.state.name == "terminated" }
       end
 
       def module_name_of(instance)

--- a/lib/terraforming/resource/eip.rb
+++ b/lib/terraforming/resource/eip.rb
@@ -47,7 +47,7 @@ module Terraforming
       private
 
       def eips
-        @client.describe_addresses.addresses
+        @client.describe_addresses.map(&:addresses).flatten
       end
 
       def is_vpc?(addr)

--- a/lib/terraforming/resource/elasti_cache_cluster.rb
+++ b/lib/terraforming/resource/elasti_cache_cluster.rb
@@ -57,7 +57,7 @@ module Terraforming
       private
 
       def cache_clusters
-        @client.describe_cache_clusters(show_cache_node_info: true).cache_clusters
+        @client.describe_cache_clusters(show_cache_node_info: true).map(&:cache_clusters).flatten
       end
 
       def cluster_in_vpc?(cache_cluster)

--- a/lib/terraforming/resource/elasti_cache_subnet_group.rb
+++ b/lib/terraforming/resource/elasti_cache_subnet_group.rb
@@ -41,7 +41,7 @@ module Terraforming
       private
 
       def cache_subnet_groups
-        @client.describe_cache_subnet_groups.cache_subnet_groups
+        @client.describe_cache_subnet_groups.map(&:cache_subnet_groups).flatten
       end
 
       def subnet_ids_of(cache_subnet_group)

--- a/lib/terraforming/resource/elb.rb
+++ b/lib/terraforming/resource/elb.rb
@@ -181,7 +181,7 @@ module Terraforming
       end
 
       def load_balancers
-        @client.describe_load_balancers.load_balancer_descriptions
+        @client.describe_load_balancers.map(&:load_balancer_descriptions).flatten
       end
 
       def load_balancer_attributes_of(load_balancer)

--- a/lib/terraforming/resource/iam_group.rb
+++ b/lib/terraforming/resource/iam_group.rb
@@ -43,7 +43,7 @@ module Terraforming
       private
 
       def iam_groups
-        @client.list_groups.collect {|r| r.groups}.flatten
+        @client.list_groups.map(&:groups).flatten
       end
     end
   end

--- a/lib/terraforming/resource/iam_group_membership.rb
+++ b/lib/terraforming/resource/iam_group_membership.rb
@@ -48,7 +48,7 @@ module Terraforming
       end
 
       def iam_groups
-        @client.list_groups.groups
+        @client.list_groups.map(&:groups).flatten
       end
 
       def membership_name_of(group)

--- a/lib/terraforming/resource/iam_group_policy.rb
+++ b/lib/terraforming/resource/iam_group_policy.rb
@@ -45,12 +45,12 @@ module Terraforming
         "#{policy.group_name}_#{policy.policy_name}"
       end
 
-      def iam_groups
-        @client.list_groups.groups
-      end
-
       def iam_group_policy_id_of(policy)
         "#{policy.group_name}:#{policy.policy_name}"
+      end
+
+      def iam_groups
+        @client.list_groups.map(&:groups).flatten
       end
 
       def iam_group_policy_names_in(group)

--- a/lib/terraforming/resource/iam_instance_profile.rb
+++ b/lib/terraforming/resource/iam_instance_profile.rb
@@ -43,7 +43,7 @@ module Terraforming
       private
 
       def iam_instance_profiles
-        @client.list_instance_profiles.instance_profiles
+        @client.list_instance_profiles.map(&:instance_profiles).flatten
       end
     end
   end

--- a/lib/terraforming/resource/iam_policy.rb
+++ b/lib/terraforming/resource/iam_policy.rb
@@ -44,7 +44,7 @@ module Terraforming
       private
 
       def iam_policies
-        @client.list_policies(scope: "Local").collect {|r| r.policies}.flatten
+        @client.list_policies(scope: "Local").map(&:policies).flatten
       end
 
       def iam_policy_description(policy)

--- a/lib/terraforming/resource/iam_role.rb
+++ b/lib/terraforming/resource/iam_role.rb
@@ -45,7 +45,7 @@ module Terraforming
       private
 
       def iam_roles
-        @client.list_roles.collect {|r| r.roles}.flatten
+        @client.list_roles.map(&:roles).flatten
       end
     end
   end

--- a/lib/terraforming/resource/iam_role_policy.rb
+++ b/lib/terraforming/resource/iam_role_policy.rb
@@ -45,12 +45,12 @@ module Terraforming
         "#{policy.role_name}_#{policy.policy_name}"
       end
 
-      def iam_roles
-        @client.list_roles.roles
-      end
-
       def iam_role_policy_id_of(policy)
         "#{policy.role_name}:#{policy.policy_name}"
+      end
+
+      def iam_roles
+        @client.list_roles.map(&:roles).flatten
       end
 
       def iam_role_policy_names_in(role)

--- a/lib/terraforming/resource/iam_user.rb
+++ b/lib/terraforming/resource/iam_user.rb
@@ -43,7 +43,7 @@ module Terraforming
       private
 
       def iam_users
-        @client.list_users.collect {|r| r.users}.flatten
+        @client.list_users.map(&:users).flatten
       end
 
       def module_name_of(user)

--- a/lib/terraforming/resource/iam_user_policy.rb
+++ b/lib/terraforming/resource/iam_user_policy.rb
@@ -45,12 +45,12 @@ module Terraforming
         "#{policy.user_name}_#{policy.policy_name}"
       end
 
-      def iam_users
-        @client.list_users.users
-      end
-
       def iam_user_policy_id_of(policy)
         "#{policy.user_name}:#{policy.policy_name}"
+      end
+
+      def iam_users
+        @client.list_users.map(&:users).flatten
       end
 
       def iam_user_policy_names_in(user)

--- a/lib/terraforming/resource/internet_gateway.rb
+++ b/lib/terraforming/resource/internet_gateway.rb
@@ -43,7 +43,7 @@ module Terraforming
       private
 
       def internet_gateways
-        @client.describe_internet_gateways.internet_gateways
+        @client.describe_internet_gateways.map(&:internet_gateways).flatten
       end
 
       def module_name_of(internet_gateway)

--- a/lib/terraforming/resource/launch_configuration.rb
+++ b/lib/terraforming/resource/launch_configuration.rb
@@ -96,9 +96,7 @@ module Terraforming
       end
 
       def launch_configurations
-        @client.describe_launch_configurations.collect do |r|
-          r.launch_configurations
-        end.flatten
+        @client.describe_launch_configurations.map(&:launch_configurations).flatten
       end
 
       def module_name_of(launch_configuration)

--- a/lib/terraforming/resource/network_acl.rb
+++ b/lib/terraforming/resource/network_acl.rb
@@ -68,7 +68,7 @@ module Terraforming
       end
 
       def network_acls
-        @client.describe_network_acls.network_acls
+        @client.describe_network_acls.map(&:network_acls).flatten
       end
 
       def subnet_ids_of(network_acl)

--- a/lib/terraforming/resource/network_interface.rb
+++ b/lib/terraforming/resource/network_interface.rb
@@ -61,7 +61,7 @@ module Terraforming
       end
 
       def network_interfaces
-        @client.describe_network_interfaces.network_interfaces
+        @client.describe_network_interfaces.map(&:network_interfaces).flatten
       end
 
     end

--- a/lib/terraforming/resource/opsworks_custom_layer.rb
+++ b/lib/terraforming/resource/opsworks_custom_layer.rb
@@ -103,7 +103,7 @@ module Terraforming
       private
 
       def stacks
-        @client.describe_stacks.stacks
+        @client.describe_stacks.map(&:stacks).flatten
       end
 
       def stack_layers(stack_id)

--- a/lib/terraforming/resource/opsworks_stack.rb
+++ b/lib/terraforming/resource/opsworks_stack.rb
@@ -69,7 +69,7 @@ module Terraforming
       private
 
       def stacks
-        @client.describe_stacks.stacks
+        @client.describe_stacks.map(&:stacks).flatten
       end
 
       def module_name_of(stack)

--- a/lib/terraforming/resource/rds.rb
+++ b/lib/terraforming/resource/rds.rb
@@ -63,7 +63,7 @@ module Terraforming
       private
 
       def db_instances
-        @client.describe_db_instances.db_instances
+        @client.describe_db_instances.map(&:db_instances).flatten
       end
 
       def module_name_of(instance)

--- a/lib/terraforming/resource/redshift.rb
+++ b/lib/terraforming/resource/redshift.rb
@@ -56,7 +56,7 @@ module Terraforming
       private
 
       def clusters
-        @client.describe_clusters.clusters
+        @client.describe_clusters.map(&:clusters).flatten
       end
 
       def module_name_of(cluster)

--- a/lib/terraforming/resource/route53_record.rb
+++ b/lib/terraforming/resource/route53_record.rb
@@ -52,7 +52,7 @@ module Terraforming
       private
 
       def hosted_zones
-        @client.list_hosted_zones.hosted_zones
+        @client.list_hosted_zones.map(&:hosted_zones).flatten
       end
 
       def record_id_of(record, zone_id)

--- a/lib/terraforming/resource/route53_zone.rb
+++ b/lib/terraforming/resource/route53_zone.rb
@@ -49,7 +49,7 @@ module Terraforming
       private
 
       def hosted_zones
-        @client.list_hosted_zones.hosted_zones.map { |hosted_zone| @client.get_hosted_zone(id: hosted_zone.id) }
+        @client.list_hosted_zones.map(&:hosted_zones).flatten.map { |hosted_zone| @client.get_hosted_zone(id: hosted_zone.id) }
       end
 
       def tags_of(hosted_zone)

--- a/lib/terraforming/resource/route_table.rb
+++ b/lib/terraforming/resource/route_table.rb
@@ -57,7 +57,7 @@ module Terraforming
       end
 
       def route_tables
-        @client.describe_route_tables.route_tables
+        @client.describe_route_tables.map(&:route_tables).flatten
       end
 
       def routes_attributes_of(route_table)

--- a/lib/terraforming/resource/route_table_association.rb
+++ b/lib/terraforming/resource/route_table_association.rb
@@ -52,7 +52,7 @@ module Terraforming
       end
 
       def route_tables
-        @client.describe_route_tables.route_tables
+        @client.describe_route_tables.map(&:route_tables).flatten
       end
     end
   end

--- a/lib/terraforming/resource/s3.rb
+++ b/lib/terraforming/resource/s3.rb
@@ -53,7 +53,7 @@ module Terraforming
       end
 
       def buckets
-        @client.list_buckets.buckets.select { |bucket| same_region?(bucket) }
+        @client.list_buckets.map(&:buckets).flatten.select { |bucket| same_region?(bucket) }
       end
 
       def module_name_of(bucket)

--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -153,7 +153,7 @@ module Terraforming
       end
 
       def security_groups
-        @client.describe_security_groups.security_groups
+        @client.describe_security_groups.map(&:security_groups).flatten
       end
 
       def security_groups_in(permission, security_group)

--- a/lib/terraforming/resource/sqs.rb
+++ b/lib/terraforming/resource/sqs.rb
@@ -59,7 +59,7 @@ module Terraforming
       end
 
       def queue_urls
-        @client.list_queues.queue_urls
+        @client.list_queues.map(&:queue_urls).flatten
       end
 
       def module_name_of(queue)

--- a/lib/terraforming/resource/subnet.rb
+++ b/lib/terraforming/resource/subnet.rb
@@ -44,7 +44,7 @@ module Terraforming
       private
 
       def subnets
-        @client.describe_subnets.subnets
+        @client.describe_subnets.map(&:subnets).flatten
       end
 
       def module_name_of(subnet)

--- a/lib/terraforming/resource/vpc.rb
+++ b/lib/terraforming/resource/vpc.rb
@@ -56,7 +56,7 @@ module Terraforming
       end
 
       def vpcs
-        @client.describe_vpcs.vpcs
+        @client.describe_vpcs.map(&:vpcs).flatten
       end
 
       def vpc_attribute(vpc, attribute)

--- a/lib/terraforming/resource/vpn_gateway.rb
+++ b/lib/terraforming/resource/vpn_gateway.rb
@@ -44,7 +44,7 @@ module Terraforming
       private
 
       def vpn_gateways
-        @client.describe_vpn_gateways.vpn_gateways
+        @client.describe_vpn_gateways.map(&:vpn_gateways).flatten
       end
 
       def module_name_of(vpn_gateway)

--- a/lib/terraforming/util.rb
+++ b/lib/terraforming/util.rb
@@ -26,5 +26,6 @@ module Terraforming
         json.strip
       end
     end
+
   end
 end

--- a/spec/lib/terraforming/resource/iam_group_spec.rb
+++ b/spec/lib/terraforming/resource/iam_group_spec.rb
@@ -27,7 +27,15 @@ module Terraforming
       end
 
       before do
-        client.stub_responses(:list_groups, groups: groups)
+        client.stub_responses(:list_groups, [{
+                                               groups: [groups[0]],
+                                               is_truncated: true,
+                                               marker: 'marker'
+                                             }, {
+                                               groups: [groups[1]],
+                                               is_truncated: false,
+                                               marker: nil
+                                             }])
       end
 
       describe ".tf" do


### PR DESCRIPTION
The resources API has a super clean way of enumerating without tons of
boilerplate `while resp.is_truncated` loops.

I only did this for a few resource types because I wanted to check in with @dtan4 about using the resources API and didn't want to do the same work x20 if it's not mergeable.