### PR TITLE
Fix name of "iampa" subcommand in CLI help output.

### DIFF
--- a/lib/terraforming/cli.rb
+++ b/lib/terraforming/cli.rb
@@ -76,7 +76,7 @@ module Terraforming
       execute(Terraforming::Resource::IAMPolicy, options)
     end
 
-    desc "iamp", "IAM Policy Attachment"
+    desc "iampa", "IAM Policy Attachment"
     def iampa
       execute(Terraforming::Resource::IAMPolicyAttachment, options)
     end


### PR DESCRIPTION
Both "iamp" and "iampa" were listed as "iamp" in the help output, which caused the "export all" example in the readme to mistakenly overwrite "iamp" output.