### PR TITLE
Fix network_interface naming in EIP

### DIFF
--- a/lib/terraforming/template/tf/eip.erb
+++ b/lib/terraforming/template/tf/eip.erb
@@ -1,11 +1,11 @@
 <% eips.each do |addr| -%>
 resource "aws_eip" "<%= addr.allocation_id %>" {
 <% if addr.instance_id -%>
-    instance             = "<%= addr.instance_id %>"
+    instance          = "<%= addr.instance_id %>"
 <% elsif addr.network_interface_id -%>
-    network_interface_id = "<%= addr.network_interface_id %>"
+    network_interface = "<%= addr.network_interface_id %>"
 <% end -%>
-    vpc                  = <%= is_vpc?(addr) %>
+    vpc               = <%= is_vpc?(addr) %>
 }
 
 <% end -%>

--- a/spec/lib/terraforming/resource/eip_spec.rb
+++ b/spec/lib/terraforming/resource/eip_spec.rb
@@ -44,17 +44,17 @@ module Terraforming
         it "should generate tf" do
           expect(described_class.tf(client: client)).to eq <<-EOS
 resource "aws_eip" "eipalloc-87654321" {
-    instance             = "i-12345678"
-    vpc                  = true
+    instance          = "i-12345678"
+    vpc               = true
 }
 
 resource "aws_eip" "eipalloc-76543210" {
-    network_interface_id = "eni-23456789"
-    vpc                  = true
+    network_interface = "eni-23456789"
+    vpc               = true
 }
 
 resource "aws_eip" "eipalloc-33333333" {
-    vpc                  = true
+    vpc               = true
 }
 
           EOS


### PR DESCRIPTION
Close #233 

`network_interface_id` is invalid. The correct key name is `network_interface`.

## REF
- [AWS: aws_eip - Terraform by HashiCorp](https://www.terraform.io/docs/providers/aws/r/eip.html#network_interface)