### PR TITLE
AWS-scoped IAM policy attachments

### DIFF
--- a/lib/terraforming/resource/iam_policy_attachment.rb
+++ b/lib/terraforming/resource/iam_policy_attachment.rb
@@ -65,7 +65,7 @@ module Terraforming
       end
 
       def iam_policies
-        @client.list_policies(scope: "Local").map(&:policies).flatten
+        @client.list_policies(scope: "All", only_attached: true).map(&:policies).flatten
       end
 
       def iam_policy_attachments


### PR DESCRIPTION
This branch is based on stripe/paginate_group_members so includes the changes in #248.

We generate only Local-scoped policies in iamp, which is fine. We need to generate both Local- and AWS-scoped attachments though, so that users/groups/roles with AWS-scoped policies (such as `arn:aws:iam::aws:policy/AmazonS3FullAccess`) are generated.