### PR TITLE
Add a new command-line option: --match

### DIFF
--- a/lib/terraforming/cli.rb
+++ b/lib/terraforming/cli.rb
@@ -1,5 +1,6 @@
 module Terraforming
   class CLI < Thor
+    class_option :match, type: :string, desc: "Match only resources with this regex pattern"
     class_option :merge, type: :string, desc: "tfstate file to merge"
     class_option :overwrite, type: :boolean, desc: "Overwrite existng tfstate"
     class_option :tfstate, type: :boolean, desc: "Generate tfstate"
@@ -222,13 +223,13 @@ module Terraforming
     end
 
     def tf(klass)
-      klass.tf
+      klass.tf(options[:match])
     end
 
     def tfstate(klass, tfstate_path)
       tfstate = tfstate_path ? JSON.parse(open(tfstate_path).read) : tfstate_skeleton
       tfstate["serial"] = tfstate["serial"] + 1
-      tfstate["modules"][0]["resources"] = tfstate["modules"][0]["resources"].merge(klass.tfstate)
+      tfstate["modules"][0]["resources"] = tfstate["modules"][0]["resources"].merge(klass.tfstate(options[:match]))
       JSON.pretty_generate(tfstate)
     end
 

--- a/lib/terraforming/resource/auto_scaling_group.rb
+++ b/lib/terraforming/resource/auto_scaling_group.rb
@@ -3,16 +3,17 @@ module Terraforming
     class AutoScalingGroup
       include Terraforming::Util
 
-      def self.tf(client: Aws::AutoScaling::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::AutoScaling::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::AutoScaling::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::AutoScaling::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/db_parameter_group.rb
+++ b/lib/terraforming/resource/db_parameter_group.rb
@@ -3,16 +3,17 @@ module Terraforming
     class DBParameterGroup
       include Terraforming::Util
 
-      def self.tf(client: Aws::RDS::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::RDS::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::RDS::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::RDS::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/db_security_group.rb
+++ b/lib/terraforming/resource/db_security_group.rb
@@ -3,16 +3,17 @@ module Terraforming
     class DBSecurityGroup
       include Terraforming::Util
 
-      def self.tf(client: Aws::RDS::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::RDS::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::RDS::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::RDS::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/db_subnet_group.rb
+++ b/lib/terraforming/resource/db_subnet_group.rb
@@ -3,16 +3,17 @@ module Terraforming
     class DBSubnetGroup
       include Terraforming::Util
 
-      def self.tf(client: Aws::RDS::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::RDS::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::RDS::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::RDS::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/eip.rb
+++ b/lib/terraforming/resource/eip.rb
@@ -3,16 +3,17 @@ module Terraforming
     class EIP
       include Terraforming::Util
 
-      def self.tf(client: Aws::EC2::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::EC2::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/elasti_cache_cluster.rb
+++ b/lib/terraforming/resource/elasti_cache_cluster.rb
@@ -3,16 +3,17 @@ module Terraforming
     class ElastiCacheCluster
       include Terraforming::Util
 
-      def self.tf(client: Aws::ElastiCache::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::ElastiCache::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::ElastiCache::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::ElastiCache::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/elasti_cache_subnet_group.rb
+++ b/lib/terraforming/resource/elasti_cache_subnet_group.rb
@@ -3,16 +3,17 @@ module Terraforming
     class ElastiCacheSubnetGroup
       include Terraforming::Util
 
-      def self.tf(client: Aws::ElastiCache::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::ElastiCache::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::ElastiCache::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::ElastiCache::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/elb.rb
+++ b/lib/terraforming/resource/elb.rb
@@ -3,16 +3,17 @@ module Terraforming
     class ELB
       include Terraforming::Util
 
-      def self.tf(client: Aws::ElasticLoadBalancing::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::ElasticLoadBalancing::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::ElasticLoadBalancing::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::ElasticLoadBalancing::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/iam_group.rb
+++ b/lib/terraforming/resource/iam_group.rb
@@ -3,16 +3,17 @@ module Terraforming
     class IAMGroup
       include Terraforming::Util
 
-      def self.tf(client: Aws::IAM::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::IAM::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/iam_group_membership.rb
+++ b/lib/terraforming/resource/iam_group_membership.rb
@@ -3,16 +3,17 @@ module Terraforming
     class IAMGroupMembership
       include Terraforming::Util
 
-      def self.tf(client: Aws::IAM::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::IAM::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/iam_group_policy.rb
+++ b/lib/terraforming/resource/iam_group_policy.rb
@@ -3,16 +3,17 @@ module Terraforming
     class IAMGroupPolicy
       include Terraforming::Util
 
-      def self.tf(client: Aws::IAM::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::IAM::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/iam_instance_profile.rb
+++ b/lib/terraforming/resource/iam_instance_profile.rb
@@ -3,16 +3,17 @@ module Terraforming
     class IAMInstanceProfile
       include Terraforming::Util
 
-      def self.tf(client: Aws::IAM::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::IAM::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/iam_policy.rb
+++ b/lib/terraforming/resource/iam_policy.rb
@@ -3,16 +3,17 @@ module Terraforming
     class IAMPolicy
       include Terraforming::Util
 
-      def self.tf(client: Aws::IAM::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::IAM::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/iam_policy_attachment.rb
+++ b/lib/terraforming/resource/iam_policy_attachment.rb
@@ -3,16 +3,17 @@ module Terraforming
     class IAMPolicyAttachment
       include Terraforming::Util
 
-      def self.tf(client: Aws::IAM::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::IAM::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/iam_role.rb
+++ b/lib/terraforming/resource/iam_role.rb
@@ -3,16 +3,17 @@ module Terraforming
     class IAMRole
       include Terraforming::Util
 
-      def self.tf(client: Aws::IAM::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::IAM::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/iam_role_policy.rb
+++ b/lib/terraforming/resource/iam_role_policy.rb
@@ -3,16 +3,17 @@ module Terraforming
     class IAMRolePolicy
       include Terraforming::Util
 
-      def self.tf(client: Aws::IAM::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::IAM::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/iam_user.rb
+++ b/lib/terraforming/resource/iam_user.rb
@@ -3,16 +3,17 @@ module Terraforming
     class IAMUser
       include Terraforming::Util
 
-      def self.tf(client: Aws::IAM::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::IAM::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/iam_user_policy.rb
+++ b/lib/terraforming/resource/iam_user_policy.rb
@@ -3,16 +3,17 @@ module Terraforming
     class IAMUserPolicy
       include Terraforming::Util
 
-      def self.tf(client: Aws::IAM::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::IAM::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::IAM::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/internet_gateway.rb
+++ b/lib/terraforming/resource/internet_gateway.rb
@@ -3,16 +3,17 @@ module Terraforming
     class InternetGateway
       include Terraforming::Util
 
-      def self.tf(client: Aws::EC2::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::EC2::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/launch_configuration.rb
+++ b/lib/terraforming/resource/launch_configuration.rb
@@ -3,16 +3,17 @@ module Terraforming
     class LaunchConfiguration
       include Terraforming::Util
 
-      def self.tf(client: Aws::AutoScaling::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::AutoScaling::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::AutoScaling::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::AutoScaling::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/nat_gateway.rb
+++ b/lib/terraforming/resource/nat_gateway.rb
@@ -3,16 +3,17 @@ module Terraforming
     class NATGateway
       include Terraforming::Util
 
-      def self.tf(client: Aws::EC2::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::EC2::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/network_acl.rb
+++ b/lib/terraforming/resource/network_acl.rb
@@ -3,16 +3,17 @@ module Terraforming
     class NetworkACL
       include Terraforming::Util
 
-      def self.tf(client: Aws::EC2::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::EC2::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/network_interface.rb
+++ b/lib/terraforming/resource/network_interface.rb
@@ -3,16 +3,17 @@ module Terraforming
     class NetworkInterface
       include Terraforming::Util
 
-      def self.tf(client: Aws::EC2::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::EC2::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/opsworks_custom_layer.rb
+++ b/lib/terraforming/resource/opsworks_custom_layer.rb
@@ -3,16 +3,17 @@ module Terraforming
     class OpsWorksCustomLayer
       include Terraforming::Util
 
-      def self.tf(client: Aws::OpsWorks::Client.new(region: 'us-east-1'))
-        self.new(client).tf
+      def self.tf(match, client: Aws::OpsWorks::Client.new(region: 'us-east-1'))
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::OpsWorks::Client.new(region: 'us-east-1'))
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::OpsWorks::Client.new(region: 'us-east-1'))
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/opsworks_stack.rb
+++ b/lib/terraforming/resource/opsworks_stack.rb
@@ -3,16 +3,17 @@ module Terraforming
     class OpsWorksStack
       include Terraforming::Util
 
-      def self.tf(client: Aws::OpsWorks::Client.new(region: 'us-east-1'))
-        self.new(client).tf
+      def self.tf(match, client: Aws::OpsWorks::Client.new(region: 'us-east-1'))
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::OpsWorks::Client.new(region: 'us-east-1'))
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::OpsWorks::Client.new(region: 'us-east-1'))
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/route_table.rb
+++ b/lib/terraforming/resource/route_table.rb
@@ -3,16 +3,17 @@ module Terraforming
     class RouteTable
       include Terraforming::Util
 
-      def self.tf(client: Aws::EC2::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::EC2::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/route_table_association.rb
+++ b/lib/terraforming/resource/route_table_association.rb
@@ -3,16 +3,17 @@ module Terraforming
     class RouteTableAssociation
       include Terraforming::Util
 
-      def self.tf(client: Aws::EC2::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::EC2::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf

--- a/lib/terraforming/resource/s3.rb
+++ b/lib/terraforming/resource/s3.rb
@@ -3,16 +3,17 @@ module Terraforming
     class S3
       include Terraforming::Util
 
-      def self.tf(client: Aws::S3::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::S3::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::S3::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::S3::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf
@@ -53,7 +54,9 @@ module Terraforming
       end
 
       def buckets
-        @client.list_buckets.map(&:buckets).flatten.select { |bucket| same_region?(bucket) }
+        @client.list_buckets.map(&:buckets).flatten.select do |resource|
+          @match_regex ? module_name_of(resource) =~ @match_regex : 1
+        end.select { |bucket| same_region?(bucket) }
       end
 
       def module_name_of(bucket)

--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -3,16 +3,17 @@ module Terraforming
     class SecurityGroup
       include Terraforming::Util
 
-      def self.tf(client: Aws::EC2::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::EC2::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf
@@ -154,7 +155,9 @@ module Terraforming
       end
 
       def security_groups
-        @client.describe_security_groups.map(&:security_groups).flatten
+        @client.describe_security_groups.map(&:security_groups).flatten.select do |resource|
+          @match_regex ? module_name_of(resource) =~ @match_regex : 1
+        end
       end
 
       def security_groups_in(permission, security_group)

--- a/lib/terraforming/resource/subnet.rb
+++ b/lib/terraforming/resource/subnet.rb
@@ -3,16 +3,17 @@ module Terraforming
     class Subnet
       include Terraforming::Util
 
-      def self.tf(client: Aws::EC2::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::EC2::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf
@@ -44,7 +45,9 @@ module Terraforming
       private
 
       def subnets
-        @client.describe_subnets.map(&:subnets).flatten
+        @client.describe_subnets.map(&:subnets).flatten.select do |resource|
+          @match_regex ? module_name_of(resource) =~ @match_regex : 1
+        end
       end
 
       def module_name_of(subnet)

--- a/lib/terraforming/resource/vpn_gateway.rb
+++ b/lib/terraforming/resource/vpn_gateway.rb
@@ -3,16 +3,17 @@ module Terraforming
     class VPNGateway
       include Terraforming::Util
 
-      def self.tf(client: Aws::EC2::Client.new)
-        self.new(client).tf
+      def self.tf(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tf
       end
 
-      def self.tfstate(client: Aws::EC2::Client.new)
-        self.new(client).tfstate
+      def self.tfstate(match, client: Aws::EC2::Client.new)
+        self.new(client, match).tfstate
       end
 
-      def initialize(client)
+      def initialize(client, match)
         @client = client
+        @match_regex = Regexp.new(match) if match
       end
 
       def tf
@@ -44,7 +45,9 @@ module Terraforming
       private
 
       def vpn_gateways
-        @client.describe_vpn_gateways.map(&:vpn_gateways).flatten
+        @client.describe_vpn_gateways.map(&:vpn_gateways).flatten.select do |resource|
+          @match_regex ? module_name_of(resource) =~ @match_regex : 1
+        end
       end
 
       def module_name_of(vpn_gateway)


### PR DESCRIPTION
The match option will only export configuration and tfstate for
items that match the regular expression specified.  This is not
supported for all types, but is very useful for ec2 and r53r
exports.

This works for the few types I've implemented, but it is far from
complete.  I'm not too familiar with Ruby so I wanted to get
some early feedback to see if I'm on the right track.  It would also
need some tests I'm sure.