### PR TITLE
Readme runall example

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,11 @@ Example assuming you want to export everything from us-west-2 and you are using 
 ```bash
 export AWS_REGION=us-west-2
 terraforming help | grep terraforming | grep -v help | awk '{print "terraforming", $2, "--profile", "default", ">", $2".tf";}' | bash
-# remove files that only have 1 empty line (nothing in AWS)
+
+# If you want to generate tfstate files for the above export
+terraforming help | grep terraforming | grep -v help | awk '{print "terraforming", $2, "--tfstate", "--profile", "default", ">", $2".tfstate";}' | bash
+
+# remove tf/tfstate files that only have 1 empty line (nothing in AWS)
 find . -type f -name '*.tf*' | xargs wc -l | grep '1 .' | awk '{print $2;}' | xargs rm
 ```
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Example assuming you want to export everything from us-west-2 and you are using 
 export AWS_REGION=us-west-2
 terraforming help | grep terraforming | grep -v help | awk '{print "terraforming", $2, "--profile", "default", ">", $2".tf";}' | bash
 # remove files that only have 1 empty line (nothing in AWS)
-find . -type f | xargs wc -l | grep '1 .' | awk '{print $2;}' | xargs rm
+find . -type f -name '*.tf*' | xargs wc -l | grep '1 .' | awk '{print $2;}' | xargs rm
 ```
 
 ## Run as Docker container [![Docker Repository on Quay.io](https://quay.io/repository/dtan4/terraforming/status "Docker Repository on Quay.io")](https://quay.io/repository/dtan4/terraforming)


### PR DESCRIPTION
While I was working with terraforming for the first time I was also using git to track changes to my .tf and tfstate files. I noticed that after I ran the export all example that it had also deleted large portions of my local git repository.

This update accomplishes two goals:

1. Updates the find command in the example to only find files that match the '\*.tf\*' glob
2. Adds an example for generating tfstate files along with the intial tf files.

I didn't bump the version in version.rb though since it's just a doc change, I'll leave that up to your discretion if you agree with this change.