### PR TITLE
Remove commands to delete empty files in export

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,8 @@ Example assuming you want to export everything from us-west-2 and you are using 
 ```bash
 export AWS_REGION=us-west-2
 terraforming help | grep terraforming | grep -v help | awk '{print "terraforming", $2, "--profile", "default", ">", $2".tf";}' | bash
-# remove files that only have 1 empty line (nothing in AWS)
-find . -type f | xargs wc -l | grep '1 .' | awk '{print $2;}' | xargs rm
+# find files that only have 1 empty line (likely nothing in AWS)
+find . -type f -name '*.tf' | xargs wc -l | grep ' 1 .'
 ```
 
 ## Run as Docker container [![Docker Repository on Quay.io](https://quay.io/repository/dtan4/terraforming/status "Docker Repository on Quay.io")](https://quay.io/repository/dtan4/terraforming)


### PR DESCRIPTION
This seems like a really bad idea, at least the way it's described here. In my local, fairly empty directory, `find . -type f | xargs wc -l | grep '1 .'` returns:

```
       1 ./.git/COMMIT_EDITMSG
       1 ./.git/description
       1 ./.git/HEAD
       1 ./.git/logs/HEAD
       1 ./.git/logs/refs/heads/master
      11 ./.git/objects/42/14eb21b7be0687ccb477ec1e5a8ecdf7711b05
       1 ./.git/objects/5e/001b34698fe2cd0da484fa9ab896e42df155b9
       1 ./.git/refs/heads/master
       1 ./.gitignore
       1 ./asg.tf
       1 ./dbsg.tf
       1 ./dbsn.tf
       1 ./ec2.tf
       1 ./ecc.tf
       1 ./ecsn.tf
       1 ./eip.tf
       1 ./elb.tf
       1 ./iamp.tf
       1 ./iamrp.tf
       1 ./igw.tf
       1 ./lc.tf
       1 ./nacl.tf
       1 ./nif.tf
       1 ./r53r.tf
       1 ./r53z.tf
       1 ./rds.tf
       1 ./rs.tf
       1 ./rt.tf
       1 ./rta.tf
       1 ./sn.tf
       1 ./sqs.tf
       1 ./vgw.tf
       1 ./vpc.tf
```

As you can see, it is deleting _anything_ in the folder with 1 line in it. Not only that, it's deleting _anything_ with a count of lines _ending_ in 1. So 11, 21, 9991 line files would be deleted as well.

This checks that the files match `'*.tf'` and adds a space before the `1` in the grep command to fix those issues. It also removes the `xargs rm`.