### PR TITLE
Generate iops field only with io1 volume

### DIFF
--- a/lib/terraforming/template/tf/ec2.erb
+++ b/lib/terraforming/template/tf/ec2.erb
@@ -27,10 +27,10 @@ resource "aws_instance" "<%= module_name_of(instance) %>" {
     root_block_device {
         volume_type           = "<%= block_device.volume_type %>"
         volume_size           = <%= block_device.size %>
-<%- if block_device.iops -%>
+        delete_on_termination = <%= mapping.ebs.delete_on_termination %>
+<%- if block_device.volume_type == "io1" && block_device.iops -%>
         iops                  = <%= block_device.iops %>
 <%- end -%>
-        delete_on_termination = <%= mapping.ebs.delete_on_termination %>
     }
 <%- else -%>
     ebs_block_device {
@@ -38,10 +38,10 @@ resource "aws_instance" "<%= module_name_of(instance) %>" {
         snapshot_id           = "<%= block_device.snapshot_id %>"
         volume_type           = "<%= block_device.volume_type %>"
         volume_size           = <%= block_device.size %>
-<%- if block_device.iops -%>
+        delete_on_termination = <%= mapping.ebs.delete_on_termination %>
+<%- if block_device.volume_type == "io1" && block_device.iops -%>
         iops                  = <%= block_device.iops %>
 <%- end -%>
-        delete_on_termination = <%= mapping.ebs.delete_on_termination %>
     }
 <% end -%>
 

--- a/spec/lib/terraforming/resource/ec2_spec.rb
+++ b/spec/lib/terraforming/resource/ec2_spec.rb
@@ -278,7 +278,8 @@ module Terraforming
                 delete_on_termination: true
               }
             ],
-            volume_type: "standard",
+            volume_type: "io1",
+            iops: 24,
             encrypted: false
           }
         ]
@@ -332,9 +333,10 @@ resource "aws_instance" "hoge" {
     source_dest_check           = true
 
     root_block_device {
-        volume_type           = "standard"
+        volume_type           = "io1"
         volume_size           = 8
         delete_on_termination = true
+        iops                  = 24
     }
 
     tags {
@@ -360,7 +362,6 @@ resource "aws_instance" "i-5678efgh" {
         snapshot_id           = "snap-5678efgh"
         volume_type           = "gp2"
         volume_size           = 8
-        iops                  = 24
         delete_on_termination = true
     }
 


### PR DESCRIPTION
Close https://github.com/dtan4/terraforming/issues/266

## WHY

`iops` of EC2 `root_block_device` and `ebs_block_device` must be set with `io1` (Provisioned IOPS SSD) volume.

## WHAT

Generate `iops1` only when the `volume_type` is `io1`.

## REF

- [AWS: aws_instance - Terraform by HashiCorp](https://www.terraform.io/docs/providers/aws/r/instance.html)