### PR TITLE
Update gems

### DIFF
--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 2.5.1"
+  spec.add_dependency "aws-sdk", "~> 2.6.1"
   spec.add_dependency "oj", "~> 2.17.1"
   spec.add_dependency "ox", "~> 2.4.0"
   spec.add_dependency "thor"

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "coveralls", "~> 0.8.13"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.2"
-  spec.add_development_dependency "simplecov", "~> 0.11.1"
+  spec.add_development_dependency "simplecov", "~> 0.12.0"
 end


### PR DESCRIPTION
## WHY

Some of gems version specification are outdated.

## WHAT

Update outdated gems

- aws-sdk: 2.5.x -> 2.6.x ([CHANGELOG](https://github.com/wantedly/wantedly/blob/a0a1d00ad4362d19ff4bab6429f63476e8918e94/app/models/user.rb#L10))
- simplecov: 0.11.x -> 0.12.x ([CHANGELOG](https://github.com/aws/aws-sdk-ruby/blob/220d7f5d081600739035876b8dd9da1120021fb7/CHANGELOG.md))