### PR TITLE
Remove native extension gems and use wrapper gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,13 @@ rvm:
 - 2.2.5
 - 2.1.10
 env:
-- secure: n0mxwnyjuXI4mJO4mp++2TnsPJ+XgCF/J1U2L5piE5j3xMhSU+5V0JrA1uFlS0Pemb44M7BjgmF9S4G35BwyAQpctpCYhqy9tFa6+Y6nxEv5hCv2cZz7BSAZM6eb+zq20409hxTHRaQOr1DBeE4R5S2PrmOXRqvYfTRv3LNSLFk=
+  global:
+    - secure: n0mxwnyjuXI4mJO4mp++2TnsPJ+XgCF/J1U2L5piE5j3xMhSU+5V0JrA1uFlS0Pemb44M7BjgmF9S4G35BwyAQpctpCYhqy9tFa6+Y6nxEv5hCv2cZz7BSAZM6eb+zq20409hxTHRaQOr1DBeE4R5S2PrmOXRqvYfTRv3LNSLFk=
+  matrix:
+    - OJ=0
+    - OJ=1
+before_script:
+  - if [[ $OJ -eq 1 ]]; then gem install oj; fi
 notifications:
   slack:
     secure: iTI8zpxXQJqf5e9ix4buLRsGlf9lJRZqA9Fawdqm41msBrC0Zsp31XzBS7ZPiTcdHhImtOC4lccTCW2C8kR6waaG5VOF0U2BwyKaNFKsXMaVk6yrNhYkvJ9YVicuU9hL+JKLyBrSDYQ7+vXcHqaz4H4dYpPThrv6sfq4jBOp+eM=

--- a/lib/terraforming.rb
+++ b/lib/terraforming.rb
@@ -1,13 +1,5 @@
 require "multi_json"
 
-begin
-  require "ox"
-rescue NameError => e
-  spec = Gem::Specification.stubs.find { |s| s.name == 'ox' }
-  raise e unless spec
-  require File.join(spec.gem_dir, "lib/ox")
-end
-
 require "aws-sdk-core"
 require "erb"
 require "json"

--- a/lib/terraforming.rb
+++ b/lib/terraforming.rb
@@ -1,8 +1,6 @@
-require "multi_json"
-
 require "aws-sdk-core"
 require "erb"
-require "json"
+require "multi_json"
 require "thor"
 require "zlib"
 

--- a/lib/terraforming.rb
+++ b/lib/terraforming.rb
@@ -1,4 +1,4 @@
-require "oj"
+require "multi_json"
 
 begin
   require "ox"

--- a/lib/terraforming/cli.rb
+++ b/lib/terraforming/cli.rb
@@ -221,10 +221,10 @@ module Terraforming
     end
 
     def tfstate(klass, tfstate_path)
-      tfstate = tfstate_path ? JSON.parse(open(tfstate_path).read) : tfstate_skeleton
+      tfstate = tfstate_path ? MultiJson.load(open(tfstate_path).read) : tfstate_skeleton
       tfstate["serial"] = tfstate["serial"] + 1
       tfstate["modules"][0]["resources"] = tfstate["modules"][0]["resources"].merge(klass.tfstate)
-      JSON.pretty_generate(tfstate)
+      MultiJson.encode(tfstate, pretty: true)
     end
 
     def tfstate_skeleton

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk", "~> 2.6.1"
   spec.add_dependency "multi_json", "~> 1.12.1"
-  spec.add_dependency "ox", "~> 2.4.0"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "aws-sdk", "~> 2.6.1"
-  spec.add_dependency "oj", "~> 2.17.1"
+  spec.add_dependency "multi_json", "~> 1.12.1"
   spec.add_dependency "ox", "~> 2.4.0"
   spec.add_dependency "thor"
 


### PR DESCRIPTION
## WHY

Ox and Oj installations sometimes occur error by environment. It should be that users can choose gems to use. For example, some users use built-in json gem, others user oj and ox gems for speed.

## WHAT

Remove dependency of oj gem and introduce [multi_json](https://github.com/intridea/multi_json) gem. multi_json gem loads the fastest JSON gem from installed gems automatically.

In addition, ox gem dependency is also removed. aws-sdk gem loads the fastest gem from installed gems automatically.