### PR TITLE
Prepeare code skeleton generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,41 @@ I love pull requests from everyone! By the way, I have a favor to ask you with y
 - Command name should be abbreviation.
   - e.g. `aws_iam_group_membership`: `iamgp`
 - Please check generation result by executing `terraform plan` with real resources. There should be NO diff with generated `.tf` and `.tfstate`.
+
+`script/generate` generates new resource code / test skeletons.
+
+```bash
+$ script/generate ec2
+==> Generate ec2.rb
+==> Generate ec2_spec.rb
+==> Generate ec2.erb
+
+Add below code by hand.
+
+lib/terraforming.rb:
+
+    require "terraforming/resource/ec2"
+
+lib/terraforming/cli.rb:
+
+    module Terraforming
+      class CLI < Thor
+
+        # Subcommand name should be acronym.
+        desc "ec2", "Ec2"
+        def ec2
+          execute(Terraforming::Resource::Ec2, options)
+        end
+
+spec/lib/terraforming/cli_spec.rb:
+
+module Terraforming
+  describe CLI do
+    context "resources" do
+    describe "ec2" do
+        let(:klass)   { Terraforming::Resource::Ec2
+        let(:command) { :ec2 }
+
+        it_behaves_like "CLI examples"
+      end
+```

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,6 @@ group :development do
   gem "rubocop"
 
   gem "terminal-notifier-guard"
+
+  gem "activesupport", "~> 5.0.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,4 @@ group :development do
   gem "rubocop"
 
   gem "terminal-notifier-guard"
-
-  gem "activesupport", "~> 5.0.0"
 end

--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
+Please read [Contribution Guide](CONTRIBUTING.md) at first.
+
 1. Fork it ( https://github.com/dtan4/terraforming/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)

--- a/script/generate
+++ b/script/generate
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+
+require "erb"
+
+USAGE = <<-EOS
+Usage: script/generate RESOURCE
+RESOURCE must be snake_case
+
+Example:
+  script/generate EC2
+EOS
+
+def camelize(string)
+  string.sub(/^[a-z\d]*/) { |match| match.capitalize }.gsub(/(?:_|(\/))([a-z\d]*)/i) { "#{$1}#{$2.capitalize}" }.gsub('/'.freeze, '::'.freeze)
+end
+
+def generate_resource_erb(resource)
+  template = File.join("templates", "resource.erb.erb")
+  ERB.new(open(template).read, nil, "-").result(binding)
+end
+
+def generate_resource_rb(resource)
+  template = File.expand_path(File.join("templates", "resource.rb.erb"))
+  ERB.new(open(template).read, nil, "-").result(binding)
+end
+
+def generate_resource_spec_rb(resource)
+  template = File.join("templates", "resource_spec.rb.erb")
+  ERB.new(open(template).read, nil, "-").result(binding)
+end
+
+def humanize(string)
+  string.sub(/\A_+/, ''.freeze).sub(/_id\z/, ''.freeze).tr('_'.freeze, ' '.freeze).gsub(/([a-z\d]*)/i) do |match|
+    match.downcase
+  end.split(" ").map{ |w| w[0].upcase + w[1..-1] }.join(" ")
+end
+
+
+
+if ARGV.length != 1
+  $stderr.puts USAGE
+  exit 1
+end
+
+resource = ARGV[0]
+
+puts "==> Generate #{resource}.rb"
+resource_rb = generate_resource_rb(resource)
+File.open(File.join("lib", "terraforming", "resource", "#{resource}.rb"), "w+") { |f| f.write(resource_rb) }
+
+puts "==> Generate #{resource}_spec.rb"
+resource_spec_rb = generate_resource_spec_rb(resource)
+File.open(File.join("spec", "lib", "terraforming", "resource", "#{resource}_spec.rb"), "w+") { |f| f.write(resource_rb)}
+
+puts "==> Generate #{resource}.erb"
+resource_erb = generate_resource_erb(resource)
+File.open(File.join("lib", "terraforming", "template", "tf", "#{resource}.erb"), "w+") { |f| f.write(resource_rb) }
+
+puts <<-EOS
+
+Add below code by hand.
+
+lib/terraforming.rb:
+
+    require "terraforming/resource/#{resource}"
+
+lib/terraforming/cli.rb:
+
+    module Terraforming
+      class CLI < Thor
+
+        # Subcommand name should be acronym.
+        desc "#{resource}", "#{humanize(resource)}"
+        def #{resource}
+          execute(Terraforming::Resource::#{camelize(resource)}, options)
+        end
+
+spec/lib/terraforming/cli_spec.rb:
+
+module Terraforming
+  describe CLI do
+    context "resources" do
+    describe "#{resource}" do
+        let(:klass)   { Terraforming::Resource::#{camelize(resource) }
+        let(:command) { :#{resource} }
+
+        it_behaves_like "CLI examples"
+      end
+EOS

--- a/templates/resource.erb.erb
+++ b/templates/resource.erb.erb
@@ -1,0 +1,3 @@
+resource "aws_<%= resource %>" "resource_name" {
+
+}

--- a/templates/resource.rb.erb
+++ b/templates/resource.rb.erb
@@ -1,0 +1,31 @@
+module Terraforming
+  module Resource
+    class <%= camelize(resource) %>
+      include Terraforming::Util
+
+      # TODO: Select appropriate Client class from here:
+      # http://docs.aws.amazon.com/sdkforruby/api/index.html
+      def self.tf(client: Aws::SomeResource::Client.new)
+        self.new(client).tf
+      end
+
+      # TODO: Select appropriate Client class from here:
+      # http://docs.aws.amazon.com/sdkforruby/api/index.html
+      def self.tfstate(client: Aws::SomeResource::Client.new)
+        self.new(client).tfstate
+      end
+
+      def initialize(client)
+        @client = client
+      end
+
+      def tf
+        apply_template(@client, "tf/<%= resource %>")
+      end
+
+      def tfstate
+
+      end
+    end
+  end
+end

--- a/templates/resource_spec.rb.erb
+++ b/templates/resource_spec.rb.erb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+module Terraforming
+  module Resource
+    describe <%= camelize(resource) %> do
+      let(:client) do
+        # TODO: Select appropriate Client class from here:
+        # http://docs.aws.amazon.com/sdkforruby/api/index.html
+        Aws::SomeResource::Client.new(stub_responses: true)
+      end
+
+      describe ".tf" do
+        it "should generate tf" do
+          expect(described_class.tf(client: client)).to eq <<-EOS
+resource "aws_<%= resource %>" "resource_name" {
+
+}
+
+        EOS
+        end
+      end
+
+      describe ".tfstate" do
+        it "should generate tfstate" do
+          expect(described_class.tfstate(client: client)).to eq({
+            "aws_<%= resource %>.resource_name" => {
+              "type" => "aws_<%= resource %>",
+              "primary" => {
+                "id" => "",
+                "attributes" => {
+                }
+              }
+            }
+          })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## WHY

To add new resource to Terraforming, developers have to...

- Create 3 new files 
  - `lib/terraforming/resource/resource.rb`
  - `lib/terraforming/template/tf/resource.erb`
  - `spec/lib/terraforming/resource/resource_spec.rb`
- Modify 3 files
  - `lib/terraforming.rb`
  - `lib/terraforming/cli.rb`
  - `spec/lib/terraforming/cli_spec.rb`

It's troublesome to add them by hand.

## WHAT

Preapare skeleton generator script. It creates 3 new files and guides how to modify other files.