### PR TITLE
Fixes for route53_records

### DIFF
--- a/lib/terraforming/resource/route53_record.rb
+++ b/lib/terraforming/resource/route53_record.rb
@@ -35,6 +35,12 @@ module Terraforming
           attributes["records.#"] = record.resource_records.length.to_s unless record.resource_records.empty?
           attributes["ttl"] = record.ttl.to_s if record.ttl
           attributes["weight"] = record.weight ? record.weight.to_s : "-1"
+          attributes["region"] = record.region if record.region
+          if record.geo_location
+            attributes["continent"] = record.geo_location.continent_code if record.geo_location.continent_code
+            attributes["country"] = record.geo_location.country_code if record.geo_location.country_code
+            attributes["subdivision"] = record.geo_location.subdivision_code if record.geo_location.subdivision_code
+          end
           attributes["set_identifier"] = record.set_identifier if record.set_identifier
 
           resources["aws_route53_record.#{module_name_of(record)}"] = {

--- a/lib/terraforming/resource/route53_record.rb
+++ b/lib/terraforming/resource/route53_record.rb
@@ -77,17 +77,12 @@ module Terraforming
           record_sets_of(hosted_zone).map { |record| { record: record, zone_id: zone_id_of(hosted_zone) } }
         end.flatten
         count = {}
-        dups = to_return.group_by{ |record| module_name_of(record[:record], nil) }.select { |k, v| v.size > 1 }.map(&:first)
+        dups = to_return.group_by { |record| module_name_of(record[:record], nil) }.select { |_, v| v.size > 1 }.map(&:first)
         to_return.each do |r|
           module_name = module_name_of(r[:record], nil)
-          if dups.include?(module_name)
-            if count[module_name]
-              count[module_name] = count[module_name] + 1
-            else
-              count[module_name] = 0
-            end
-            r[:counter] = count[module_name]
-          end
+          next unless dups.include?(module_name)
+          count[module_name] = count[module_name] ? count[module_name] + 1 : 0
+          r[:counter] = count[module_name]
         end
         to_return
       end

--- a/lib/terraforming/resource/route53_record.rb
+++ b/lib/terraforming/resource/route53_record.rb
@@ -37,11 +37,13 @@ module Terraforming
           attributes["ttl"] = record.ttl.to_s if record.ttl
           attributes["weight"] = record.weight ? record.weight.to_s : "-1"
           attributes["region"] = record.region if record.region
+
           if record.geo_location
             attributes["continent"] = record.geo_location.continent_code if record.geo_location.continent_code
             attributes["country"] = record.geo_location.country_code if record.geo_location.country_code
             attributes["subdivision"] = record.geo_location.subdivision_code if record.geo_location.subdivision_code
           end
+
           attributes["set_identifier"] = record.set_identifier if record.set_identifier
 
           resources["aws_route53_record.#{module_name_of(record, counter)}"] = {

--- a/lib/terraforming/template/tf/route53_record.erb
+++ b/lib/terraforming/template/tf/route53_record.erb
@@ -1,6 +1,7 @@
 <% records.each do |r| -%>
   <%- record, zone_id = r[:record], r[:zone_id] -%>
-resource "aws_route53_record" "<%= module_name_of(record) %>" {
+  <%- counter = r[:counter] -%>
+resource "aws_route53_record" "<%= module_name_of(record, counter) %>" {
     zone_id = "<%= zone_id %>"
     name    = "<%= name_of(record.name.sub(/\\052/, '*')) %>"
     type    = "<%= record.type %>"

--- a/lib/terraforming/template/tf/route53_record.erb
+++ b/lib/terraforming/template/tf/route53_record.erb
@@ -13,24 +13,24 @@ resource "aws_route53_record" "<%= module_name_of(record, counter) %>" {
 <%- end -%>
 <%- if record.weight -%>
     weighted_routing_policy {
-      weight = <%= record.weight %>
+        weight = <%= record.weight %>
     }
 <%- end -%>
 <%- if record.region -%>
     latency_routing_policy {
-      region = "<%= record.region %>"
+        region = "<%= record.region %>"
     }
 <%- end -%>
 <%- if record.geo_location -%>
     geolocation_routing_policy {
   <%- if record.geo_location.continent_code -%>
-      continent = "<%= record.geo_location.continent_code %>"
+        continent = "<%= record.geo_location.continent_code %>"
   <%- end -%>
   <%- if record.geo_location.country_code -%>
-      country = "<%= record.geo_location.country_code %>"
+        country = "<%= record.geo_location.country_code %>"
   <%- end -%>
   <%- if record.geo_location.subdivision_code -%>
-      subdivision = "<%= record.geo_location.subdivision_code %>"
+        subdivision = "<%= record.geo_location.subdivision_code %>"
   <%- end -%>
     }
 <%- end -%>

--- a/lib/terraforming/template/tf/route53_record.erb
+++ b/lib/terraforming/template/tf/route53_record.erb
@@ -11,7 +11,27 @@ resource "aws_route53_record" "<%= module_name_of(record) %>" {
     ttl     = "<%= record.ttl %>"
 <%- end -%>
 <%- if record.weight -%>
-    weight  = <%= record.weight %>
+    weighted_routing_policy {
+      weight = <%= record.weight %>
+    }
+<%- end -%>
+<%- if record.region -%>
+    latency_routing_policy {
+      region = "<%= record.region %>"
+    }
+<%- end -%>
+<%- if record.geo_location -%>
+    geolocation_routing_policy {
+  <%- if record.geo_location.continent_code -%>
+      continent = "<%= record.geo_location.continent_code %>"
+  <%- end -%>
+  <%- if record.geo_location.country_code -%>
+      country = "<%= record.geo_location.country_code %>"
+  <%- end -%>
+  <%- if record.geo_location.subdivision_code -%>
+      subdivision = "<%= record.geo_location.subdivision_code %>"
+  <%- end -%>
+    }
 <%- end -%>
 <%- if record.set_identifier -%>
     set_identifier = "<%= record.set_identifier %>"

--- a/spec/lib/terraforming/resource/route53_record_spec.rb
+++ b/spec/lib/terraforming/resource/route53_record_spec.rb
@@ -109,7 +109,7 @@ resource "aws_route53_record" "www-fuga-net-A" {
     name    = "www.fuga.net"
     type    = "A"
     weighted_routing_policy {
-      weight = 10
+        weight = 10
     }
 
     alias {

--- a/spec/lib/terraforming/resource/route53_record_spec.rb
+++ b/spec/lib/terraforming/resource/route53_record_spec.rb
@@ -108,7 +108,9 @@ resource "aws_route53_record" "www-fuga-net-A" {
     zone_id = "OPQRSTUVWXYZAB"
     name    = "www.fuga.net"
     type    = "A"
-    weight  = 10
+    weighted_routing_policy {
+      weight = 10
+    }
 
     alias {
         name    = "fuga.net"


### PR DESCRIPTION
This PR is for a couple of changes for resources of `aws_route53_record` type:
  * `weight` should be wrapped in a `weighted_routing_policy {}` block.
  * Added support for routing policies other than weighted (i.e. latency and geolocation)
  * Don't use duplicate resource names; differentiate similarly-named resource names with a counter.