### PR TITLE
Fix support for EIP in EC2-Classic

### DIFF
--- a/lib/terraforming/resource/eip.rb
+++ b/lib/terraforming/resource/eip.rb
@@ -24,7 +24,7 @@ module Terraforming
           attributes = {
             "association_id" => addr.association_id,
             "domain" => addr.domain,
-            "id" => addr.allocation_id,
+            "id" => vpc?(addr) ? addr.allocation_id : addr.public_ip,
             "instance" => addr.instance_id,
             "network_interface" => addr.network_interface_id,
             "private_ip" => addr.private_ip_address,
@@ -35,7 +35,7 @@ module Terraforming
           resources["aws_eip.#{module_name_of(addr)}"] = {
             "type" => "aws_eip",
             "primary" => {
-              "id" => addr.allocation_id,
+              "id" => vpc?(addr) ? addr.allocation_id : addr.public_ip,
               "attributes" => attributes
             }
           }
@@ -55,7 +55,11 @@ module Terraforming
       end
 
       def module_name_of(addr)
-        normalize_module_name(addr.allocation_id)
+        if vpc?(addr)
+          normalize_module_name(addr.allocation_id)
+        else
+          normalize_module_name(addr.public_ip)
+        end
       end
     end
   end

--- a/spec/lib/terraforming/resource/eip_spec.rb
+++ b/spec/lib/terraforming/resource/eip_spec.rb
@@ -33,6 +33,16 @@ module Terraforming
             domain: "vpc",
             allocation_id: "eipalloc-33333333",
           },
+          {
+            instance_id: "i-91112221",
+            public_ip: "2.2.2.4",
+            allocation_id: nil,
+            association_id: nil,
+            domain: "standard",
+            network_interface_id: nil,
+            network_interface_owner_id: nil,
+            private_ip_address: nil
+          }
         ]
       end
 
@@ -55,6 +65,11 @@ resource "aws_eip" "eipalloc-76543210" {
 
 resource "aws_eip" "eipalloc-33333333" {
     vpc               = true
+}
+
+resource "aws_eip" "2-2-2-4" {
+    instance          = "i-91112221"
+    vpc               = false
 }
 
           EOS
@@ -106,6 +121,19 @@ resource "aws_eip" "eipalloc-33333333" {
                     "vpc" => "true"
                 }
               }
+            },
+            "aws_eip.2-2-2-4" => {
+              "type" => "aws_eip",
+              "primary" => {
+                "id" => "2.2.2.4",
+                "attributes" => {
+                    "domain" => "standard",
+                    "id" => "2.2.2.4",
+                    "instance" => "i-91112221",
+                    "public_ip" => "2.2.2.4",
+                    "vpc" => "false"
+                },
+              },
             },
           })
         end


### PR DESCRIPTION
For EC2-Classic, the allocation_id is nil, which causes an error, so the ID and the module name should be derived from IP address rather than the allocation_id.