### PR TITLE
Rename title of aws_route53_record with wildcard.

### DIFF
--- a/lib/terraforming/resource/route53_record.rb
+++ b/lib/terraforming/resource/route53_record.rb
@@ -95,7 +95,7 @@ module Terraforming
       end
 
       def module_name_of(record, counter)
-        normalize_module_name(name_of(record.name) + "-" + record.type + (!counter.nil? ? "-" + counter.to_s : ""))
+        normalize_module_name(name_of(record.name.gsub(/\\052/, 'wildcard')) + "-" + record.type + (!counter.nil? ? "-" + counter.to_s : ""))
       end
 
       def zone_id_of(hosted_zone)

--- a/spec/lib/terraforming/resource/route53_record_spec.rb
+++ b/spec/lib/terraforming/resource/route53_record_spec.rb
@@ -137,7 +137,7 @@ resource "aws_route53_record" "www-fuga-net-A" {
     }
 }
 
-resource "aws_route53_record" "-052-example-net-CNAME" {
+resource "aws_route53_record" "wildcard-example-net-CNAME" {
     zone_id = "CDEFGHIJKLMNOP"
     name    = "*.example.net"
     type    = "CNAME"
@@ -204,7 +204,7 @@ resource "aws_route53_record" "geo-example-net-A-1" {
                 },
               }
             },
-            "aws_route53_record.-052-example-net-CNAME" => {
+            "aws_route53_record.wildcard-example-net-CNAME" => {
               "type" => "aws_route53_record",
               "primary" => {
                 "id" => "CDEFGHIJKLMNOP_*.example.net_CNAME",


### PR DESCRIPTION
Normalize '-052' to 'wildcard'.

See https://github.com/dtan4/terraforming/issues/347

This renames the title of an `aws_route53_record` with a wildcard to a string which can be reused without having to modify the output of `terraform r53r (--tfstate)`.

```
resource "aws_route53_record" "-052-example-net-CNAME" {
    zone_id = "XYZ"
    name    = "*.example.net"
    type    = "CNAME"
    records = ["example.net."]
    ttl     = "1800"
}
```

->

```
resource "aws_route53_record" "wildcard-example-net-CNAME" {
    zone_id = "XYZ"
    name    = "*.example.net"
    type    = "CNAME"
    records = ["example.net."]
    ttl     = "1800"
}
```