### PR TITLE
Add icmp_code and icmp_type to NACL tf

### DIFF
--- a/lib/terraforming/template/tf/network_acl.erb
+++ b/lib/terraforming/template/tf/network_acl.erb
@@ -11,6 +11,10 @@ resource "aws_network_acl" "<%= module_name_of(network_acl) %>" {
         action     = "<%= ingress.rule_action %>"
         protocol   = "<%= ingress.protocol %>"
         cidr_block = "<%= ingress.cidr_block %>"
+<%- if ingress.icmp_type_code -%>
+        icmp_code  = "<%= ingress.icmp_type_code.code %>"
+        icmp_type  = "<%= ingress.icmp_type_code.type %>"
+<%- end -%>
     }
 
 <% end -%>

--- a/lib/terraforming/template/tf/network_acl.erb
+++ b/lib/terraforming/template/tf/network_acl.erb
@@ -26,6 +26,10 @@ resource "aws_network_acl" "<%= module_name_of(network_acl) %>" {
         action     = "<%= egress.rule_action %>"
         protocol   = "<%= egress.protocol %>"
         cidr_block = "<%= egress.cidr_block %>"
+<%- if egress.icmp_type_code -%>
+        icmp_code  = "<%= egress.icmp_type_code.code %>"
+        icmp_type  = "<%= egress.icmp_type_code.type %>"
+<%- end -%>
     }
 
 <% end -%>

--- a/spec/lib/terraforming/resource/network_acl_spec.rb
+++ b/spec/lib/terraforming/resource/network_acl_spec.rb
@@ -76,6 +76,18 @@ module Terraforming
                 },
               },
               {
+                rule_number: 15000,
+                protocol: "1",
+                rule_action: "allow",
+                egress: true,
+                cidr_block: "0.0.0.0/0",
+                port_range: nil,
+                icmp_type_code: {
+                  code: -1,
+                  type: 4
+                },
+              },
+              {
                 rule_number: 32767,
                 protocol: "-1",
                 rule_action: "deny",
@@ -155,6 +167,17 @@ resource "aws_network_acl" "fuga" {
         icmp_type  = "10"
     }
 
+    egress {
+        from_port  = 0
+        to_port    = 0
+        rule_no    = 15000
+        action     = "allow"
+        protocol   = "1"
+        cidr_block = "0.0.0.0/0"
+        icmp_code  = "-1"
+        icmp_type  = "4"
+    }
+
     tags {
         "Name" = "fuga"
     }
@@ -186,7 +209,7 @@ resource "aws_network_acl" "fuga" {
               "primary" => {
                 "id" => "acl-5678efgh",
                 "attributes" => {
-                  "egress.#" => "0",
+                  "egress.#" => "1",
                   "id" => "acl-5678efgh",
                   "ingress.#" => "2",
                   "subnet_ids.#" => "2",

--- a/spec/lib/terraforming/resource/network_acl_spec.rb
+++ b/spec/lib/terraforming/resource/network_acl_spec.rb
@@ -64,6 +64,18 @@ module Terraforming
                 port_range: nil,
               },
               {
+                rule_number: 12345,
+                protocol: "1",
+                rule_action: "allow",
+                egress: false,
+                cidr_block: "0.0.0.0/0",
+                port_range: nil,
+                icmp_type_code: {
+                  code: -1,
+                  type: 10,
+                },
+              },
+              {
                 rule_number: 32767,
                 protocol: "-1",
                 rule_action: "deny",
@@ -132,6 +144,17 @@ resource "aws_network_acl" "fuga" {
         cidr_block = "0.0.0.0/0"
     }
 
+    ingress {
+        from_port  = 0
+        to_port    = 0
+        rule_no    = 12345
+        action     = "allow"
+        protocol   = "1"
+        cidr_block = "0.0.0.0/0"
+        icmp_code  = "-1"
+        icmp_type  = "10"
+    }
+
     tags {
         "Name" = "fuga"
     }
@@ -165,7 +188,7 @@ resource "aws_network_acl" "fuga" {
                 "attributes" => {
                   "egress.#" => "0",
                   "id" => "acl-5678efgh",
-                  "ingress.#" => "1",
+                  "ingress.#" => "2",
                   "subnet_ids.#" => "2",
                   "tags.#" => "1",
                   "vpc_id" => "vpc-5678efgh",


### PR DESCRIPTION
Resolve #339

## WHY

Network ACL Ingress/Egress rule can specify [ICMP code and type](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-types).
Terraform also specify them as its parameters.

## WHAT

Generate Network ACL tf file with `icmp_code` and `icmp_type` fields.

## REF

- [AWS: aws_network_acl - Terraform by HashiCorp](https://www.terraform.io/docs/providers/aws/r/network_acl.html)