### PR TITLE
Drop Ruby 2.1 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
 - 2.4.1
 - 2.3.4
 - 2.2.7
-- 2.1.10
 env:
   global:
     - secure: n0mxwnyjuXI4mJO4mp++2TnsPJ+XgCF/J1U2L5piE5j3xMhSU+5V0JrA1uFlS0Pemb44M7BjgmF9S4G35BwyAQpctpCYhqy9tFa6+Y6nxEv5hCv2cZz7BSAZM6eb+zq20409hxTHRaQOr1DBeE4R5S2PrmOXRqvYfTRv3LNSLFk=


### PR DESCRIPTION
## WHY

[Official support of Ruby 2.1 has ended](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/)

## WHAT

To improve CI speed, drop tests with Ruby 2.1 which is no longer supported.