### PR TITLE
Add failover attributes to Route53 record.

### DIFF
--- a/lib/terraforming/resource/route53_record.rb
+++ b/lib/terraforming/resource/route53_record.rb
@@ -44,7 +44,13 @@ module Terraforming
             attributes["subdivision"] = record.geo_location.subdivision_code if record.geo_location.subdivision_code
           end
 
+          if record.failover
+            attributes["failover_routing_policy.#"] = "1"
+            attributes["failover_routing_policy.0.type"] = record.failover
+          end
+
           attributes["set_identifier"] = record.set_identifier if record.set_identifier
+          attributes["health_check_id"] = record.health_check_id if record.health_check_id
 
           resources["aws_route53_record.#{module_name_of(record, counter)}"] = {
             "type" => "aws_route53_record",

--- a/lib/terraforming/template/tf/route53_record.erb
+++ b/lib/terraforming/template/tf/route53_record.erb
@@ -38,6 +38,15 @@ resource "aws_route53_record" "<%= module_name_of(record, counter) %>" {
 <%- if record.set_identifier -%>
     set_identifier = "<%= record.set_identifier %>"
 <%- end -%>
+<%- if record.health_check_id -%>
+    health_check_id = "<%= record.health_check_id %>"
+<%- end -%>
+    <%- if record.failover -%>
+
+    failover_routing_policy {
+        type = "<%= record.failover %>"
+    }
+    <%- end -%>
 
     <%- if record.alias_target -%>
     alias {

--- a/spec/lib/terraforming/resource/route53_record_spec.rb
+++ b/spec/lib/terraforming/resource/route53_record_spec.rb
@@ -96,6 +96,29 @@ module Terraforming
             weight: nil,
             set_identifier: nil,
           },
+          {
+            name: "failover.example.net.",
+            type: "A",
+            ttl: 3600,
+            weight: nil,
+            set_identifier: "failover_group",
+            health_check_id: "1234abcd-56ef-78gh-90ij-123456klmnop",
+            resource_records: [
+              { value: "192.0.2.101" }
+            ],
+            failover: "PRIMARY"
+          },
+          {
+            name: "failover.example.net.",
+            type: "A",
+            ttl: 3600,
+            weight: nil,
+            set_identifier: "failover_group",
+            resource_records: [
+              { value: "192.0.2.102" }
+            ],
+            failover: "SECONDARY"
+          },
         ]
       end
 
@@ -164,6 +187,35 @@ resource "aws_route53_record" "geo-example-net-A-1" {
     name    = "geo.example.net"
     type    = "A"
     ttl     = "60"
+
+}
+
+resource "aws_route53_record" "failover-example-net-A-0" {
+    zone_id = "CDEFGHIJKLMNOP"
+    name    = "failover.example.net"
+    type    = "A"
+    records = ["192.0.2.101"]
+    ttl     = "3600"
+    set_identifier = "failover_group"
+    health_check_id = "1234abcd-56ef-78gh-90ij-123456klmnop"
+
+    failover_routing_policy {
+        type = "PRIMARY"
+    }
+
+}
+
+resource "aws_route53_record" "failover-example-net-A-1" {
+    zone_id = "CDEFGHIJKLMNOP"
+    name    = "failover.example.net"
+    type    = "A"
+    records = ["192.0.2.102"]
+    ttl     = "3600"
+    set_identifier = "failover_group"
+
+    failover_routing_policy {
+        type = "SECONDARY"
+    }
 
 }
 
@@ -246,6 +298,43 @@ resource "aws_route53_record" "geo-example-net-A-1" {
                   "zone_id" => "CDEFGHIJKLMNOP",
                   "weight" => "-1",
                   "ttl" => "60",
+                },
+              }
+            },
+            "aws_route53_record.failover-example-net-A-0" => {
+              "type" => "aws_route53_record",
+              "primary" => {
+                "id" => "CDEFGHIJKLMNOP_failover.example.net_A",
+                "attributes" => {
+                  "failover_routing_policy.#" => "1",
+                  "failover_routing_policy.0.type" => "PRIMARY",
+                  "health_check_id" => "1234abcd-56ef-78gh-90ij-123456klmnop",
+                  "id" => "CDEFGHIJKLMNOP_failover.example.net_A",
+                  "name" => "failover.example.net",
+                  "type" => "A",
+                  "zone_id" => "CDEFGHIJKLMNOP",
+                  "records.#" => "1",
+                  "weight" => "-1",
+                  "ttl" => "3600",
+                  "set_identifier" => "failover_group",
+                },
+              }
+            },
+            "aws_route53_record.failover-example-net-A-1" => {
+              "type" => "aws_route53_record",
+              "primary" => {
+                "id" => "CDEFGHIJKLMNOP_failover.example.net_A",
+                "attributes" => {
+                  "failover_routing_policy.#" => "1",
+                  "failover_routing_policy.0.type" => "SECONDARY",
+                  "id" => "CDEFGHIJKLMNOP_failover.example.net_A",
+                  "name" => "failover.example.net",
+                  "type" => "A",
+                  "zone_id" => "CDEFGHIJKLMNOP",
+                  "records.#" => "1",
+                  "weight" => "-1",
+                  "ttl" => "3600",
+                  "set_identifier" => "failover_group",
                 },
               }
             },


### PR DESCRIPTION
The attributes about DNS failiover (the following 2 attributes) are missing in the exported Route53 tf and tfstate files, so this PR adds them.

* "failover_routing_policy"
* "health_check_id"