### PR TITLE
Ignore external key

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,10 @@ terraforming help | grep terraforming | grep -v help | awk '{print "terraforming
 find . -type f -name '*.tf' | xargs wc -l | grep ' 1 .'
 ```
 
+### Caveats
+
+- `terraforming kmsk` does not export EXTERNAL origin key, bacause Terraform does not support it.
+
 ## Run as Docker container [![Docker Repository on Quay.io](https://quay.io/repository/dtan4/terraforming/status "Docker Repository on Quay.io")](https://quay.io/repository/dtan4/terraforming)
 
 Terraforming Docker Image is available at [quay.io/dtan4/terraforming](https://quay.io/repository/dtan4/terraforming) and developed at [dtan4/dockerfile-terraforming](https://github.com/dtan4/dockerfile-terraforming).

--- a/lib/terraforming/resource/kms_key.rb
+++ b/lib/terraforming/resource/kms_key.rb
@@ -54,6 +54,7 @@ module Terraforming
           .reject { |key| managed_master_key?(key) }
           .map { |key| @client.describe_key(key_id: key.key_id) }
           .map(&:key_metadata)
+          .reject { |metadata| metadata.origin == "EXTERNAL" } # external origin key is not supoprted by Terraform
       end
 
       def key_policy_of(key)

--- a/spec/lib/terraforming/resource/kms_key_spec.rb
+++ b/spec/lib/terraforming/resource/kms_key_spec.rb
@@ -21,6 +21,10 @@ module Terraforming
             key_id: "12ab34cd-56ef-12ab-34cd-12ab34cd56ef",
             key_arn: "arn:aws:kms:ap-northeast-1:123456789012:key/12ab34cd-56ef-12ab-34cd-12ab34cd56ef",
           },
+          {
+            key_id: "ab12cd34-ef56-ab12-cd34-ab12cd34ef56",
+            key_arn: "arn:aws:kms:ap-northeast-1:123456789012:key/ab12cd34-ef56-ab12-cd34-ab12cd34ef56",
+          },
         ]
       end
 
@@ -56,18 +60,18 @@ module Terraforming
         }
       end
 
-      let(:piyo_key) do
+      let(:foobar_key) do
         {
           key_metadata: {
             aws_account_id: "123456789012",
-            key_id: "12ab34cd-56ef-12ab-34cd-12ab34cd56ef",
-            arn: "arn:aws:kms:ap-northeast-1:123456789012:key/12ab34cd-56ef-12ab-34cd-12ab34cd56ef",
-            creation_date: Time.new("2016-09-09 12:34:56 +0900"),
+            key_id: "ab12cd34-ef56-ab12-cd34-ab12cd34ef56",
+            arn: "arn:aws:kms:ap-northeast-1:123456789012:key/ab12cd34-ef56-ab12-cd34-ab12cd34ef56",
+            creation_date: Time.new("2017-09-09 12:34:56 +0900"),
             enabled: true,
-            description: "Default master key that protects my ACM private keys when no other key is defined",
+            description: "Default master key that protects my ACM private keys when no other key is foobar",
             key_usage: "ENCRYPT_DECRYPT",
-            key_state: "Enabled",
-            origin: "AWS_KMS",
+            key_state: "PendingImport",
+            origin: "EXTERNAL",
           },
         }
       end
@@ -88,6 +92,11 @@ module Terraforming
             alias_name: "alias/fuga",
             alias_arn: "arn:aws:kms:ap-northeast-1:123456789012:alias/fuga",
             target_key_id: "abcd1234-ab12-cd34-ef56-abcdef123456"
+          },
+          {
+            alias_name: "alias/foobar",
+            alias_arn: "arn:aws:kms:ap-northeast-1:123456789012:alias/foobar",
+            target_key_id: "ab12cd34-ef56-ab12-cd34-ab12cd34ef56"
           },
         ]
       end
@@ -186,7 +195,7 @@ EOS
       before do
         client.stub_responses(:list_keys, keys: keys)
         client.stub_responses(:list_aliases, aliases: aliases)
-        client.stub_responses(:describe_key, [hoge_key, fuga_key, piyo_key])
+        client.stub_responses(:describe_key, [hoge_key, fuga_key, foobar_key])
         client.stub_responses(:list_key_policies, [hoge_policies, fuga_policies])
         client.stub_responses(:get_key_policy, [hoge_policy, fuga_policy])
         client.stub_responses(:get_key_rotation_status, [hoge_key_rotation_status, fuga_key_rotation_status])


### PR DESCRIPTION
Fix #361 

## WHY

[`Aws::KMS::Client#get_key_rotation_status`](http://docs.aws.amazon.com/sdkforruby/api/Aws/KMS/Client.html#get_key_rotation_status-instance_method) does not support external origin key. In addition, Terraform does not support it too.

## WHAT

Ignore external origin key by `terraforming kmsk [--tfstate]` command.