### PR TITLE
Fix iam instance profile

### DIFF
--- a/lib/terraforming/resource/iam_instance_profile.rb
+++ b/lib/terraforming/resource/iam_instance_profile.rb
@@ -26,6 +26,7 @@ module Terraforming
             "id" => profile.instance_profile_name,
             "name" => profile.instance_profile_name,
             "path" => profile.path,
+            "role" => profile.roles[0].role_name,
             "roles.#" => profile.roles.length.to_s,
           }
           resources["aws_iam_instance_profile.#{module_name_of(profile)}"] = {

--- a/lib/terraforming/template/tf/iam_instance_profile.erb
+++ b/lib/terraforming/template/tf/iam_instance_profile.erb
@@ -1,8 +1,8 @@
 <% iam_instance_profiles.each do |profile| -%>
 resource "aws_iam_instance_profile" "<%= module_name_of(profile) %>" {
-    name  = "<%= profile.instance_profile_name %>"
-    path  = "<%= profile.path %>"
-    roles = <%= profile.roles.map { |role| role.role_name }.inspect %>
+    name = "<%= profile.instance_profile_name %>"
+    path = "<%= profile.path %>"
+    role = "<%= profile.roles[0].role_name %>"
 }
 
 <% end -%>

--- a/spec/lib/terraforming/resource/iam_instance_profile_spec.rb
+++ b/spec/lib/terraforming/resource/iam_instance_profile_spec.rb
@@ -25,15 +25,7 @@ module Terraforming
                 assume_role_policy_document: "%7B%22Version%22%3A%222008-10-17%22%2C%22Statement%22%3A%5B%7B%22Sid%22%3A%22%22%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D",
               },
             ],
-          },
-          {
-            path: "/system/",
-            instance_profile_name: "fuga_profile",
-            instance_profile_id: "OPQRSTUVWXYZA8901234",
-            arn: "arn:aws:iam::345678901234:instance-profile/fuga_profile",
-            create_date: Time.parse("2015-05-01 12:34:56 UTC"),
-            roles: [],
-          },
+          }
         ]
       end
 
@@ -45,15 +37,9 @@ module Terraforming
         it "should generate tf" do
           expect(described_class.tf(client: client)).to eq <<-EOS
 resource "aws_iam_instance_profile" "hoge_profile" {
-    name  = "hoge_profile"
-    path  = "/"
-    roles = ["hoge_role"]
-}
-
-resource "aws_iam_instance_profile" "fuga_profile" {
-    name  = "fuga_profile"
-    path  = "/system/"
-    roles = []
+    name = "hoge_profile"
+    path = "/"
+    role = "hoge_role"
 }
 
         EOS
@@ -72,20 +58,8 @@ resource "aws_iam_instance_profile" "fuga_profile" {
                   "id" => "hoge_profile",
                   "name" => "hoge_profile",
                   "path" => "/",
+                  "role" => "hoge_role",
                   "roles.#" => "1",
-                }
-              }
-            },
-            "aws_iam_instance_profile.fuga_profile" => {
-              "type" => "aws_iam_instance_profile",
-              "primary" => {
-                "id" => "fuga_profile",
-                "attributes" => {
-                  "arn" => "arn:aws:iam::345678901234:instance-profile/fuga_profile",
-                  "id" => "fuga_profile",
-                  "name" => "fuga_profile",
-                  "path" => "/system/",
-                  "roles.#" => "0",
                 }
               }
             }


### PR DESCRIPTION
Fix issue #374 .

Because the "roles" argument in aws_iam_instance_profile is deprecated,
use "role" instead in tf and tfstate.
cf: [AWS: aws_iam_instance_profile - Terraform by HashiCorp](https://www.terraform.io/docs/providers/aws/r/iam_instance_profile.html)

In addition, remove the test case with 0 role. In this case, terraform will output the following error.
```
Error applying plan:

1 error(s) occurred:

* aws_iam_instance_profile.test_profile: 1 error(s) occurred:

* aws_iam_instance_profile.test_profile: Either `role` or `roles` (deprecated) must be specified when creating an IAM Instance Profile
```