### PR TITLE
Use ENCRYPT_DECRYPT as KMS key usage

### DIFF
--- a/lib/terraforming/resource/kms_key.rb
+++ b/lib/terraforming/resource/kms_key.rb
@@ -32,7 +32,7 @@ module Terraforming
                 "id" => key.key_id,
                 "is_enabled" => key.enabled.to_s,
                 "key_id" => key.key_id,
-                "key_usage" => key_usage_of(key),
+                "key_usage" => key.key_usage,
                 "policy" => key_policy_of(key),
               },
             },
@@ -67,10 +67,6 @@ module Terraforming
 
       def key_rotation_status_of(key)
         @client.get_key_rotation_status(key_id: key.key_id)
-      end
-
-      def key_usage_of(key)
-        key.key_usage.tr("_", "/")
       end
 
       def managed_master_key?(key)

--- a/lib/terraforming/template/tf/kms_key.erb
+++ b/lib/terraforming/template/tf/kms_key.erb
@@ -1,7 +1,7 @@
 <% keys.each do |key| -%>
 resource "aws_kms_key" "<%= module_name_of(key) %>" {
     description             = "<%= key.description %>"
-    key_usage               = "<%= key_usage_of(key) %>"
+    key_usage               = "<%= key.key_usage %>"
     is_enabled              = <%= key.enabled %>
     enable_key_rotation     = <%= key_rotation_status_of(key).key_rotation_enabled %>
 

--- a/spec/lib/terraforming/resource/kms_key_spec.rb
+++ b/spec/lib/terraforming/resource/kms_key_spec.rb
@@ -206,7 +206,7 @@ EOS
           expect(described_class.tf(client: client)).to eq <<-EOS
 resource "aws_kms_key" "1234abcd-12ab-34cd-56ef-1234567890ab" {
     description             = "hoge"
-    key_usage               = "ENCRYPT/DECRYPT"
+    key_usage               = "ENCRYPT_DECRYPT"
     is_enabled              = true
     enable_key_rotation     = true
 
@@ -229,7 +229,7 @@ POLICY
 
 resource "aws_kms_key" "abcd1234-ab12-cd34-ef56-abcdef123456" {
     description             = "fuga"
-    key_usage               = "ENCRYPT/DECRYPT"
+    key_usage               = "ENCRYPT_DECRYPT"
     is_enabled              = true
     enable_key_rotation     = false
 
@@ -295,7 +295,7 @@ POLICY
                   "id" => "1234abcd-12ab-34cd-56ef-1234567890ab",
                   "is_enabled" => "true",
                   "key_id" => "1234abcd-12ab-34cd-56ef-1234567890ab",
-                  "key_usage" => "ENCRYPT/DECRYPT",
+                  "key_usage" => "ENCRYPT_DECRYPT",
                   "policy" => "{\n  \"Version\" : \"2012-10-17\",\n  \"Id\" : \"key-default-1\",\n  \"Statement\" : [ {\n    \"Sid\" : \"Enable IAM User Permissions\",\n    \"Effect\" : \"Allow\",\n    \"Principal\" : {\n      \"AWS\" : \"arn:aws:iam::123456789012:root\"\n    },\n    \"Action\" : \"kms:*\",\n    \"Resource\" : \"*\"\n  } ]\n}\n",
                 }
               }
@@ -311,7 +311,7 @@ POLICY
                   "id" => "abcd1234-ab12-cd34-ef56-abcdef123456",
                   "is_enabled" => "true",
                   "key_id" => "abcd1234-ab12-cd34-ef56-abcdef123456",
-                  "key_usage" => "ENCRYPT/DECRYPT",
+                  "key_usage" => "ENCRYPT_DECRYPT",
                   "policy" => "{\n  \"Version\" : \"2012-10-17\",\n  \"Id\" : \"key-consolepolicy-2\",\n  \"Statement\" : [ {\n    \"Sid\" : \"Enable IAM User Permissions\",\n    \"Effect\" : \"Allow\",\n    \"Principal\" : {\n      \"AWS\" : \"arn:aws:iam::123456789012:root\"\n    },\n    \"Action\" : \"kms:*\",\n    \"Resource\" : \"*\"\n  }, {\n    \"Sid\" : \"Allow access for Key Administrators\",\n    \"Effect\" : \"Allow\",\n    \"Action\" : [ \"kms:Create*\", \"kms:Describe*\", \"kms:Enable*\", \"kms:List*\", \"kms:Put*\", \"kms:Update*\", \"kms:Revoke*\", \"kms:Disable*\", \"kms:Get*\", \"kms:Delete*\", \"kms:ScheduleKeyDeletion\", \"kms:CancelKeyDeletion\" ],\n    \"Resource\" : \"*\"\n  }, {\n    \"Sid\" : \"Allow use of the key\",\n    \"Effect\" : \"Allow\",\n    \"Principal\" : {\n      \"AWS\" : [ \"arn:aws:iam::123456789012:user/user1\", \"arn:aws:iam::123456789012:user/user2\" ]\n    },\n    \"Action\" : [ \"kms:Encrypt\", \"kms:Decrypt\", \"kms:ReEncrypt*\", \"kms:GenerateDataKey*\", \"kms:DescribeKey\" ],\n    \"Resource\" : \"*\"\n  }, {\n    \"Sid\" : \"Allow attachment of persistent resources\",\n    \"Effect\" : \"Allow\",\n    \"Principal\" : {\n      \"AWS\" : [ \"arn:aws:iam::123456789012:user/user1\", \"arn:aws:iam::123456789012:user/user2\" ]\n    },\n    \"Action\" : [ \"kms:CreateGrant\", \"kms:ListGrants\", \"kms:RevokeGrant\" ],\n    \"Resource\" : \"*\",\n    \"Condition\" : {\n      \"Bool\" : {\n        \"kms:GrantIsForAWSResource\" : \"true\"\n      }\n    }\n\n  } ]\n}\n",
                 }
               }


### PR DESCRIPTION
Fix #373 

## WHY

`ENCRYPT/DECRYPT` is invalid for KMS key usage. Only `ENCRYPT_DECRYPT` is acceptable.

## WHAT

Generate tf & tfstate with the value `ENCRYPT_DECRYPT`. Stop replacing `_` to `/`.

## REF

- [CreateKey - AWS Key Management Service](http://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html)