### PR TITLE
Fix cross-account security group reference

### DIFF
--- a/lib/terraforming/resource/security_group.rb
+++ b/lib/terraforming/resource/security_group.rb
@@ -172,7 +172,7 @@ module Terraforming
             range.group_id
           # EC2-Classic, other account
           else
-            "#{range.user_id}/#{range.group_name}"
+            "#{range.user_id}/#{range.group_name || range.group_id}"
           end
         end
       end


### PR DESCRIPTION
In some cases, the security group name in a permission may be nil if it is a cross-account permission. This fix allows terraforming to fall back to using the security group id.