### PR TITLE
Handle S3 AccessDenied messages

### DIFF
--- a/lib/terraforming/resource/s3.rb
+++ b/lib/terraforming/resource/s3.rb
@@ -44,6 +44,8 @@ module Terraforming
 
       def bucket_location_of(bucket)
         @client.get_bucket_location(bucket: bucket.name).location_constraint
+      rescue Aws::S3::Errors::AccessDenied
+        nil
       end
 
       def bucket_policy_of(bucket)


### PR DESCRIPTION
Certain IAM configurations allow a user/role to list buckets, but not access any information from particular ones. This should handle that edge case and allow the remainder of the S3 dump to continue gracefully