### PR TITLE
iamp-nil-check

### DIFF
--- a/lib/terraforming/template/tf/iam_instance_profile.erb
+++ b/lib/terraforming/template/tf/iam_instance_profile.erb
@@ -2,7 +2,9 @@
 resource "aws_iam_instance_profile" "<%= module_name_of(profile) %>" {
     name = "<%= profile.instance_profile_name %>"
     path = "<%= profile.path %>"
-    role = "<%= profile.roles[0].role_name %>"
+    <%- if profile.roles[0] != nil -%>
+        role = "<%= profile.roles[0].role_name %>"
+    <%- end -%>
 }
 
 <% end -%>

--- a/lib/terraforming/template/tf/iam_instance_profile.erb
+++ b/lib/terraforming/template/tf/iam_instance_profile.erb
@@ -3,7 +3,7 @@ resource "aws_iam_instance_profile" "<%= module_name_of(profile) %>" {
     name = "<%= profile.instance_profile_name %>"
     path = "<%= profile.path %>"
     <%- if profile.roles[0] != nil -%>
-        role = "<%= profile.roles[0].role_name %>"
+    role = "<%= profile.roles[0].role_name %>"
     <%- end -%>
 }
 


### PR DESCRIPTION
While running terraforming iamip  I ended up following error. This fix worked for me
```
$terraforming iamip 
...//log
1: from (erb):1:in `each'
(erb):5:in `block in apply_template': undefined method `role_name' for nil:NilClass (NoMethodError)
```