### PR TITLE
Resolve duplicate naming issue by including instance-ID

### DIFF
--- a/lib/terraforming/template/tf/ec2.erb
+++ b/lib/terraforming/template/tf/ec2.erb
@@ -1,5 +1,5 @@
 <% instances.each do |instance| -%>
-resource "aws_instance" "<%= module_name_of(instance) %>" {
+resource "aws_instance" "<%= instance.instance_id %>_<%= module_name_of(instance) %>" {
     ami                         = "<%= instance.image_id %>"
     availability_zone           = "<%= instance.placement.availability_zone %>"
     ebs_optimized               = <%= instance.ebs_optimized %>

--- a/lib/terraforming/version.rb
+++ b/lib/terraforming/version.rb
@@ -1,3 +1,3 @@
 module Terraforming
-  VERSION = "0.16.0"
+  VERSION = "0.16.1"
 end


### PR DESCRIPTION
Resolves issue #417 by prefixing the aws_instance resource names with the instance ID. This was a problem for us in that most of our EC2 instances are produced from autoscaling groups and have duplicate name tags.