### PR TITLE
Fixed undefined method 'role_name' when running iamip

### DIFF
--- a/lib/terraforming/resource/iam_instance_profile.rb
+++ b/lib/terraforming/resource/iam_instance_profile.rb
@@ -26,18 +26,22 @@ module Terraforming
             "id" => profile.instance_profile_name,
             "name" => profile.instance_profile_name,
             "path" => profile.path,
-            "role" => profile.roles[0].role_name,
             "roles.#" => profile.roles.length.to_s,
           }
-          resources["aws_iam_instance_profile.#{module_name_of(profile)}"] = {
-            "type" => "aws_iam_instance_profile",
-            "primary" => {
-              "id" => profile.instance_profile_name,
-              "attributes" => attributes
+          if profile.roles.length > 0
+            attributes["role"] = profile.roles[0].role_name
+          end
+          if attributes["role"]
+            resources["aws_iam_instance_profile.#{module_name_of(profile)}"] = {
+              "type" => "aws_iam_instance_profile",
+              "primary" => {
+                "id" => profile.instance_profile_name,
+                "attributes" => attributes
+              }
             }
-          }
-
+          end
           resources
+
         end
       end
 

--- a/lib/terraforming/template/tf/iam_instance_profile.erb
+++ b/lib/terraforming/template/tf/iam_instance_profile.erb
@@ -1,8 +1,8 @@
 <% iam_instance_profiles.each do |profile| -%>
-resource "aws_iam_instance_profile" "<%= module_name_of(profile) %>" {
+<% if profile.roles.length > 0 %>resource "aws_iam_instance_profile" "<%= module_name_of(profile) %>" {
     name = "<%= profile.instance_profile_name %>"
     path = "<%= profile.path %>"
     role = "<%= profile.roles[0].role_name %>"
-}
+}<% end %>
 
 <% end -%>


### PR DESCRIPTION
This error appears because sometimes AWS can return to you a list of instance profiles including deleted ones (as I understood this).

So, if an instance profile is actually deleted - it can't be matched with any IAM role and we getting "undefined method 'role_name'" then.

My fix is checking if profile.roles list is empty. If not - well, this profile really exists and we can get an IAM role for it, so we should add it to .tf file.