### PR TITLE
Use the latest and supported Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-- 2.5.1
-- 2.4.4
-- 2.3.7
+  # https://www.ruby-lang.org/en/downloads/branches/
+  - 2.6.x
+  - 2.5.x
+  - 2.4.x
 env:
   global:
     - secure: n0mxwnyjuXI4mJO4mp++2TnsPJ+XgCF/J1U2L5piE5j3xMhSU+5V0JrA1uFlS0Pemb44M7BjgmF9S4G35BwyAQpctpCYhqy9tFa6+Y6nxEv5hCv2cZz7BSAZM6eb+zq20409hxTHRaQOr1DBeE4R5S2PrmOXRqvYfTRv3LNSLFk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.6
   - 2.5
   - 2.4
+  # macOS system Ruby is Ruby 2.3
+  - 2.3
 env:
   global:
     - secure: n0mxwnyjuXI4mJO4mp++2TnsPJ+XgCF/J1U2L5piE5j3xMhSU+5V0JrA1uFlS0Pemb44M7BjgmF9S4G35BwyAQpctpCYhqy9tFa6+Y6nxEv5hCv2cZz7BSAZM6eb+zq20409hxTHRaQOr1DBeE4R5S2PrmOXRqvYfTRv3LNSLFk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
   # https://www.ruby-lang.org/en/downloads/branches/
-  - 2.6.x
-  - 2.5.x
-  - 2.4.x
+  - 2.6
+  - 2.5
+  - 2.4
 env:
   global:
     - secure: n0mxwnyjuXI4mJO4mp++2TnsPJ+XgCF/J1U2L5piE5j3xMhSU+5V0JrA1uFlS0Pemb44M7BjgmF9S4G35BwyAQpctpCYhqy9tFa6+Y6nxEv5hCv2cZz7BSAZM6eb+zq20409hxTHRaQOr1DBeE4R5S2PrmOXRqvYfTRv3LNSLFk=


### PR DESCRIPTION
## WHAT

Run tests with the latest and currently supported Rubies in Travis CI

Ruby 2.3 is [end-of-life (EOL) officially](https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/), however, macOS still uses this in default.
Some users run Terraforming with system Ruby (without installing the latest Ruby or using rbenv), so Terraforming should also support macOS' default Ruby.

```sh-session
$ /usr/bin/ruby -v
ruby 2.3.7p456 (2018-03-28 revision 63024) [universal.x86_64-darwin18]
```

## WHY

The tool should support the latest Ruby in its lifetime. Additionally, it doesn't have to support the old Rubies once they became end-of-life (EOL).

## REF

[Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/)