### PR TITLE
Support the latest EFS client

### DIFF
--- a/spec/lib/terraforming/resource/efs_file_system_spec.rb
+++ b/spec/lib/terraforming/resource/efs_file_system_spec.rb
@@ -18,6 +18,7 @@ module Terraforming
           owner_id: "999999999999",
           performance_mode: "generalPurpose",
           size_in_bytes: { value: 6144 },
+          tags: [],
         }
       end
 
@@ -32,6 +33,7 @@ module Terraforming
           owner_id: "999999999999",
           performance_mode: "generalPurpose",
           size_in_bytes: { value: 23481234 },
+          tags: [],
         }
       end
 

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-autoscaling", "~> 1"
   spec.add_dependency "aws-sdk-cloudwatch", "~> 1"
   spec.add_dependency "aws-sdk-ec2", "~> 1"
-  spec.add_dependency "aws-sdk-efs", "~> 1"
+  spec.add_dependency "aws-sdk-efs", "~> 1", ">= 1.13.0"
   spec.add_dependency "aws-sdk-elasticache", "~> 1"
   spec.add_dependency "aws-sdk-elasticloadbalancing", "~> 1"
   spec.add_dependency "aws-sdk-elasticloadbalancingv2", "~> 1"

--- a/terraforming.gemspec
+++ b/terraforming.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "multi_json", "~> 1.12.1"
   spec.add_dependency "thor"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "coveralls", "~> 0.8.13"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.2"


### PR DESCRIPTION
## WHAT

Upgrade EFS code to support the latest EFS client, and specify the dependency version to use aws-sdk-efs 1.13.0 or above.

## WHY

Current code fails the test

```
Failures:

  1) Terraforming::Resource::EFSFileSystem.tf should generate tf
     Failure/Error: client.stub_responses(:describe_file_systems, file_systems: [efs_description_0, efs_description_1])

     ArgumentError:
       parameter validator found 2 errors:
         - missing required parameter params[:file_systems][0][:tags]
         - missing required parameter params[:file_systems][1][:tags]
     # ./spec/lib/terraforming/resource/efs_file_system_spec.rb:39:in `block (2 levels) in <module:Resource>'

  2) Terraforming::Resource::EFSFileSystem.tfstate should generate tfstate
     Failure/Error: client.stub_responses(:describe_file_systems, file_systems: [efs_description_0, efs_description_1])

     ArgumentError:
       parameter validator found 2 errors:
         - missing required parameter params[:file_systems][0][:tags]
         - missing required parameter params[:file_systems][1][:tags]
     # ./spec/lib/terraforming/resource/efs_file_system_spec.rb:39:in `block (2 levels) in <module:Resource>'

Finished in 2.71 seconds (files took 1.84 seconds to load)
226 examples, 2 failures

Failed examples:

rspec ./spec/lib/terraforming/resource/efs_file_system_spec.rb:43 # Terraforming::Resource::EFSFileSystem.tf should generate tf
rspec ./spec/lib/terraforming/resource/efs_file_system_spec.rb:66 # Terraforming::Resource::EFSFileSystem.tfstate should generate tfstate
```