### PR TITLE
Rename Symbol of DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Commands:
   terraforming dbpg            # Database Parameter Group
   terraforming dbsg            # Database Security Group
   terraforming dbsn            # Database Subnet Group
-  terraforming ddb             # Dynamo DB
+  terraforming ddb             # DynamoDB
   terraforming ec2             # EC2
   terraforming ecc             # ElastiCache Cluster
   terraforming ecsn            # ElastiCache Subnet Group

--- a/lib/terraforming/cli.rb
+++ b/lib/terraforming/cli.rb
@@ -40,7 +40,7 @@ module Terraforming
       execute(Terraforming::Resource::DBSubnetGroup, options)
     end
 
-    desc "ddb", "Dynamo DB"
+    desc "ddb", "DynamoDB"
     def ddb
       execute(Terraforming::Resource::DynamoDb, options)
     end

--- a/lib/terraforming/cli.rb
+++ b/lib/terraforming/cli.rb
@@ -42,7 +42,7 @@ module Terraforming
 
     desc "ddb", "DynamoDB"
     def ddb
-      execute(Terraforming::Resource::DynamoDb, options)
+      execute(Terraforming::Resource::DynamoDB, options)
     end
 
     desc "ec2", "EC2"

--- a/lib/terraforming/resource/dynamo_db.rb
+++ b/lib/terraforming/resource/dynamo_db.rb
@@ -1,6 +1,6 @@
 module Terraforming
   module Resource
-    class DynamoDb
+    class DynamoDB
       include Terraforming::Util
       def self.tf(client: Aws::DynamoDB::Client.new)
         self.new(client).tf

--- a/spec/lib/terraforming/cli_spec.rb
+++ b/spec/lib/terraforming/cli_spec.rb
@@ -86,7 +86,7 @@ module Terraforming
       end
 
       describe "ddb" do
-        let(:klass)   { Terraforming::Resource::DynamoDb }
+        let(:klass)   { Terraforming::Resource::DynamoDB }
         let(:command) { :ddb }
 
         it_behaves_like "CLI examples"

--- a/spec/lib/terraforming/resource/dynamo_db_spec.rb
+++ b/spec/lib/terraforming/resource/dynamo_db_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 module Terraforming
   module Resource
-    describe DynamoDb do
+    describe DynamoDB do
       let(:client) do
         Aws::DynamoDB::Client.new(stub_responses: true)
       end


### PR DESCRIPTION
## WHAT

- Replace `Dynamo DB` to `DynamoDB`
- Rename Symbol `DynamoDb` to `DynamoDB`

## WHY

"DynamoDB" is the correct notation.
https://aws.amazon.com/dynamodb/