### PR TITLE
Fix CloudWatch alarm template about dimensions

### DIFF
--- a/lib/terraforming/template/tf/cloud_watch_alarm.erb
+++ b/lib/terraforming/template/tf/cloud_watch_alarm.erb
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_metric_alarm" "<%= normalize_module_name(alarm.alarm_na
     actions_enabled     = <%= alarm.actions_enabled %>
 <%- end -%>
 <%- unless alarm.dimensions.empty? -%>
-    dimensions {
+    dimensions          = {
 <% alarm.dimensions.each do |dimension| -%>
         <%= dimension.name %> = "<%= dimension.value %>"
 <% end -%>


### PR DESCRIPTION
There was an error in the template of CloudWatch alarm...

```
Error: Unsupported block type

  on cloudwatch_alarm.tf line 14, in resource "aws_cloudwatch_metric_alarm" "xxxxxxx":
  14:     dimensions {

Blocks of type "dimensions" are not expected here. Did you mean to define
argument "dimensions"? If so, use the equals sign to assign it a value.
```