### PR TITLE
Add tags to IAM users

### DIFF
--- a/lib/terraforming/template/tf/iam_user.erb
+++ b/lib/terraforming/template/tf/iam_user.erb
@@ -2,6 +2,14 @@
 resource "aws_iam_user" "<%= module_name_of(user) %>" {
     name = "<%= user.user_name %>"
     path = "<%= user.path %>"
+<% if user[:tags].length > 0 -%>
+
+    tags = {
+<% user[:tags].each do |tag| -%>
+        "<%= tag.key %>" = "<%= tag.value %>"
+<% end -%>
+    }
+<% end -%>
 }
 
 <% end -%>

--- a/spec/lib/terraforming/resource/iam_user_spec.rb
+++ b/spec/lib/terraforming/resource/iam_user_spec.rb
@@ -28,8 +28,31 @@ module Terraforming
         ]
       end
 
+      let(:tags_response) do
+        [
+          {
+            is_truncated: false,
+            tags: [
+              {
+                key: "Name",
+                value: "test"
+              },
+              {
+                key: "Team",
+                value: "developers"
+              }
+            ]
+          },
+          {
+            is_truncated: false,
+            tags: []
+          }
+        ]
+      end
+
       before do
         client.stub_responses(:list_users, users: users)
+        client.stub_responses(:list_user_tags, tags_response.first, tags_response.last)
       end
 
       describe ".tf" do
@@ -38,6 +61,11 @@ module Terraforming
 resource "aws_iam_user" "hoge" {
     name = "hoge"
     path = "/"
+
+    tags = {
+        "Name" = "test"
+        "Team" = "developers"
+    }
 }
 
 resource "aws_iam_user" "fuga-piyo" {
@@ -63,6 +91,10 @@ resource "aws_iam_user" "fuga-piyo" {
                   "path" => "/",
                   "unique_id" => "ABCDEFGHIJKLMN1234567",
                   "force_destroy" => "false",
+                  "tags" => {
+                    "Name" => "test",
+                    "Team" => "developers"
+                  }
                 }
               }
             },


### PR DESCRIPTION
Changed command `iamu` to include user tags in the generated terraform

As described in the [terraform documentation](https://www.terraform.io/docs/providers/aws/r/iam_user.html), user tags can be managed in the same `.tf` file as the user itself. This merge request adds this functionality so that if an user has tags, it will be reflected in the generated terraform configurations and/or state