### PR TITLE
Change CWA dimension from block to argument

### DIFF
--- a/lib/terraforming/template/tf/cloud_watch_alarm.erb
+++ b/lib/terraforming/template/tf/cloud_watch_alarm.erb
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_metric_alarm" "<%= normalize_module_name(alarm.alarm_na
     actions_enabled     = <%= alarm.actions_enabled %>
 <%- end -%>
 <%- unless alarm.dimensions.empty? -%>
-    dimensions {
+    dimensions = {
 <% alarm.dimensions.each do |dimension| -%>
         <%= dimension.name %> = "<%= dimension.value %>"
 <% end -%>

--- a/spec/lib/terraforming/resource/cloud_watch_alarm_spec.rb
+++ b/spec/lib/terraforming/resource/cloud_watch_alarm_spec.rb
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "Alarm-With-Dimensions" {
     threshold           = "10000.0"
     alarm_description   = ""
     alarm_actions       = ["arn:aws:sns:region:account:lambda-alerts"]
-    dimensions {
+    dimensions = {
         FunctionName = "beep-beep"
     }
 }


### PR DESCRIPTION
As seen [here](https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html) `dimension` is an argument, not a block. Causes errors in some versions of Terraform. 