### PR TITLE
Adding compatibility with actual terraform version

### DIFF
--- a/lib/terraforming/template/tf/alb.erb
+++ b/lib/terraforming/template/tf/alb.erb
@@ -18,9 +18,9 @@ resource "aws_alb" "<%= module_name_of(load_balancer) %>" {
     }
 
 <%- end -%>
-    tags {
+    tags = {
 <% tags.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/dynamo_db.erb
+++ b/lib/terraforming/template/tf/dynamo_db.erb
@@ -49,7 +49,7 @@ resource "aws_dynamodb_table" "<%= table.table_name -%>" {
     }
 <%- end -%>
 <%- tags(table).each do |tag| -%>
-    tags {
+    tags = {
         <%= tag.key %> = "<%= tag.value -%>"
     }
 <%- end -%>

--- a/lib/terraforming/template/tf/ec2.erb
+++ b/lib/terraforming/template/tf/ec2.erb
@@ -46,9 +46,9 @@ resource "aws_instance" "<%= module_name_of(instance) %>" {
 <% end -%>
 
 <% end -%>
-    tags {
+    tags = {
 <% instance.tags.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/elastic_file_system.erb
+++ b/lib/terraforming/template/tf/elastic_file_system.erb
@@ -10,7 +10,7 @@ resource "aws_efs_file_system" "<%= module_name_of(efs) %>" {
     performance_mode = "<%= efs.performance_mode %>"
 <% end -%>
 <% if efs.name -%>
-    tags {
+    tags = {
         Name = "<%= efs.name %>"
     }
 <% end -%>

--- a/lib/terraforming/template/tf/elb.erb
+++ b/lib/terraforming/template/tf/elb.erb
@@ -41,9 +41,9 @@ resource "aws_elb" "<%= module_name_of(load_balancer) %>" {
         timeout             = <%= load_balancer.health_check.timeout %>
     }
 
-    tags {
+    tags = {
 <% @client.describe_tags(load_balancer_names: [load_balancer.load_balancer_name]).tag_descriptions.first.tags.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/internet_gateway.erb
+++ b/lib/terraforming/template/tf/internet_gateway.erb
@@ -3,9 +3,9 @@
 resource "aws_internet_gateway" "<%= module_name_of(internet_gateway) %>" {
     vpc_id = "<%= internet_gateway.attachments[0].vpc_id %>"
 
-    tags {
+    tags = {
 <% internet_gateway.tags.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/network_acl.erb
+++ b/lib/terraforming/template/tf/network_acl.erb
@@ -33,9 +33,9 @@ resource "aws_network_acl" "<%= module_name_of(network_acl) %>" {
     }
 
 <% end -%>
-    tags {
+    tags = {
 <% network_acl.tags.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/network_interface.erb
+++ b/lib/terraforming/template/tf/network_interface.erb
@@ -11,9 +11,9 @@ resource "aws_network_interface" "<%= module_name_of(network_interface) %>" {
     }
 <% end -%>
 <% if network_interface.tag_set.length > 0 -%>
-    tags {
+    tags = {
 <% network_interface.tag_set.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 <% end -%>

--- a/lib/terraforming/template/tf/route53_zone.erb
+++ b/lib/terraforming/template/tf/route53_zone.erb
@@ -8,9 +8,9 @@ resource "aws_route53_zone" "<%= module_name_of(hosted_zone) %>" {
     vpc_region = "<%= vpc.vpc_region %>"
 <%- end -%>
 
-    tags {
+    tags = {
 <% tags_of(hosted_zone).each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/route_table.erb
+++ b/lib/terraforming/template/tf/route_table.erb
@@ -24,9 +24,9 @@ resource "aws_route_table" "<%= module_name_of(route_table) %>" {
     propagating_vgws = <%= propagaving_vgws_of(route_table).inspect %>
 
 <% end -%>
-    tags {
+    tags = {
 <% route_table.tags.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/security_group.erb
+++ b/lib/terraforming/template/tf/security_group.erb
@@ -51,9 +51,9 @@ resource "aws_security_group" "<%= module_name_of(security_group) %>" {
 
 <% end -%>
 <% if security_group.tags.length > 0 -%>
-    tags {
+    tags = {
 <% security_group.tags.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 <% end -%>

--- a/lib/terraforming/template/tf/subnet.erb
+++ b/lib/terraforming/template/tf/subnet.erb
@@ -5,9 +5,9 @@ resource "aws_subnet" "<%= module_name_of(subnet) %>" {
     availability_zone       = "<%= subnet.availability_zone %>"
     map_public_ip_on_launch = <%= subnet.map_public_ip_on_launch %>
 
-    tags {
+    tags = {
 <% subnet.tags.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/vpc.erb
+++ b/lib/terraforming/template/tf/vpc.erb
@@ -5,9 +5,9 @@ resource "aws_vpc" "<%= module_name_of(vpc) %>" {
     enable_dns_support   = <%= enable_dns_support?(vpc) %>
     instance_tenancy     = "<%= vpc.instance_tenancy %>"
 
-    tags {
+    tags = {
 <% vpc.tags.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 }

--- a/lib/terraforming/template/tf/vpn_gateway.erb
+++ b/lib/terraforming/template/tf/vpn_gateway.erb
@@ -3,9 +3,9 @@
 resource "aws_vpn_gateway" "<%= module_name_of(vpn_gateway) %>" {
     vpc_id = "<%= vpn_gateway.vpc_attachments[0].vpc_id %>"
     availability_zone = "<%= vpn_gateway.availability_zone %>"
-    tags {
+    tags = {
 <% vpn_gateway.tags.each do |tag| -%>
-        "<%= tag.key %>" = "<%= tag.value %>"
+        <%= tag.key %> = "<%= tag.value %>"
 <% end -%>
     }
 }


### PR DESCRIPTION
Yesterday I tried to use terraforming with to get ec2 instances and there was some uncompatibility with new version of terraform. In fact tags aren't declared as resource, but as a map so it changes to "tags = {" instead of "tags {" and keys in this shouldn't be specified as a String. After rebuilding it works correctly