### PR TITLE
AWS region fetching from profile - workaround.

### DIFF
--- a/lib/terraforming/cli.rb
+++ b/lib/terraforming/cli.rb
@@ -234,7 +234,11 @@ module Terraforming
 
     def configure_aws(options)
       Aws.config[:credentials] = Aws::SharedCredentials.new(profile_name: options[:profile]) if options[:profile]
-      Aws.config[:region] = options[:region] if options[:region]
+      Aws.config[:region] = if options[:region]
+                              options[:region]
+                            elsif (region = Aws.shared_config.region(options))
+                              region
+                            end
 
       if options[:assume]
         args = { role_arn: options[:assume], role_session_name: "terraforming-session-#{Time.now.to_i}" }


### PR DESCRIPTION
It is an AWS bug, as stated in this closed issue - https://github.com/dtan4/terraforming/issues/235

Indeed, it is an old one - https://github.com/aws/aws-sdk-ruby/issues/1256, let's temporarily fix it here with this PR.